### PR TITLE
Update docs to use iso instead of rfc time format

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ kubectl mtv plan start demo --cutover $(date -d "$(date +'%Y-%m-%d %H:00:00') +1
 
 **Optional Flags:**
 
-- `--cutover`: Cutover time in RFC3339 format (e.g., 2023-04-01T14:30:00Z) for warm migrations, if missing cutover is set to 1h from now.
+- `--cutover`: Cutover time in ISO8601 format (e.g., 2023-04-01T14:30:00Z) for warm migrations, if missing cutover is set to 1h from now.
 
 #### Describe Migration Plan
 
@@ -462,7 +462,7 @@ kubectl mtv plan cutover NAME [flags]
 
 **Optional Flags:**
 
-- `--cutover`: Cutover time in RFC3339 format. If not specified, current time will be used.
+- `--cutover`: Cutover time in ISO8601 format. If not specified, current time will be used.
 
 #### Delete Migration Plan
 

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -200,7 +200,7 @@ func newStartPlanCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&cutoverTimeStr, "cutover", "c", "", "Cutover time in RFC3339 format (e.g., 2023-12-31T15:30:00Z). If not provided, defaults to 1 hour from now.")
+	cmd.Flags().StringVarP(&cutoverTimeStr, "cutover", "c", "", "Cutover time in ISO8601 format (e.g., 2023-12-31T15:30:00Z, '$(date -d \"+1 hour\" --iso-8601=sec)' ). If not provided, defaults to 1 hour from now.")
 
 	return cmd
 }
@@ -337,7 +337,7 @@ func newCutoverCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&cutoverTimeStr, "cutover", "c", "", "Cutover time in RFC3339 format (e.g., 2023-12-31T15:30:00Z). If not specified, defaults to current time.")
+	cmd.Flags().StringVarP(&cutoverTimeStr, "cutover", "c", "", "Cutover time in ISO8601 format (e.g., 2023-12-31T15:30:00Z, '$(date --iso-8601=sec)'). If not specified, defaults to current time.")
 
 	return cmd
 }


### PR DESCRIPTION
Adresses: https://github.com/yaacov/kubectl-mtv/issues/9

  - [x] use ISO8601 instead of RFC3339 in docs
  - [x] add a bash `date` example in the CLI help
 
 