### PR TITLE
Add --all option

### DIFF
--- a/cmd/archive/plan.go
+++ b/cmd/archive/plan.go
@@ -1,28 +1,49 @@
 package archive
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/yaacov/kubectl-mtv/pkg/cmd/archive/plan"
 	"github.com/yaacov/kubectl-mtv/pkg/util/client"
 	"github.com/yaacov/kubectl-mtv/pkg/util/completion"
+	"github.com/yaacov/kubectl-mtv/pkg/util/flags"
 )
 
 // NewPlanCmd creates the plan archiving command
 func NewPlanCmd(kubeConfigFlags *genericclioptions.ConfigFlags) *cobra.Command {
+	var all bool
+
 	cmd := &cobra.Command{
-		Use:               "plan NAME [NAME...]",
+		Use:               "plan [NAME...] [--all]",
 		Short:             "Archive one or more migration plans",
-		Args:              cobra.MinimumNArgs(1),
+		Args:              flags.ValidateAllFlagArgs(func() bool { return all }, 1),
 		SilenceUsage:      true,
 		ValidArgsFunction: completion.PlanNameCompletion(kubeConfigFlags),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Resolve the appropriate namespace based on context and flags
 			namespace := client.ResolveNamespace(kubeConfigFlags)
 
+			var planNames []string
+			if all {
+				// Get all plan names from the namespace
+				var err error
+				planNames, err = client.GetAllPlanNames(kubeConfigFlags, namespace)
+				if err != nil {
+					return fmt.Errorf("failed to get all plan names: %v", err)
+				}
+				if len(planNames) == 0 {
+					fmt.Printf("No plans found in namespace %s\n", namespace)
+					return nil
+				}
+			} else {
+				planNames = args
+			}
+
 			// Loop over each plan name and archive it
-			for _, name := range args {
+			for _, name := range planNames {
 				err := plan.Archive(kubeConfigFlags, name, namespace, true)
 				if err != nil {
 					return err
@@ -31,6 +52,8 @@ func NewPlanCmd(kubeConfigFlags *genericclioptions.ConfigFlags) *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().BoolVar(&all, "all", false, "Archive all migration plans in the namespace")
 
 	return cmd
 }

--- a/cmd/delete/hook.go
+++ b/cmd/delete/hook.go
@@ -1,28 +1,49 @@
 package delete
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/yaacov/kubectl-mtv/pkg/cmd/delete/hook"
 	"github.com/yaacov/kubectl-mtv/pkg/util/client"
 	"github.com/yaacov/kubectl-mtv/pkg/util/completion"
+	"github.com/yaacov/kubectl-mtv/pkg/util/flags"
 )
 
 // NewHookCmd creates the delete hook command
 func NewHookCmd(kubeConfigFlags *genericclioptions.ConfigFlags) *cobra.Command {
+	var all bool
+
 	cmd := &cobra.Command{
-		Use:               "hook NAME [NAME...]",
+		Use:               "hook [NAME...] [--all]",
 		Short:             "Delete one or more migration hooks",
-		Args:              cobra.MinimumNArgs(1),
+		Args:              flags.ValidateAllFlagArgs(func() bool { return all }, 1),
 		SilenceUsage:      true,
 		ValidArgsFunction: completion.HookResourceNameCompletion(kubeConfigFlags),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Resolve the appropriate namespace based on context and flags
 			namespace := client.ResolveNamespace(kubeConfigFlags)
 
+			var hookNames []string
+			if all {
+				// Get all hook names from the namespace
+				var err error
+				hookNames, err = client.GetAllHookNames(kubeConfigFlags, namespace)
+				if err != nil {
+					return fmt.Errorf("failed to get all hook names: %v", err)
+				}
+				if len(hookNames) == 0 {
+					fmt.Printf("No hooks found in namespace %s\n", namespace)
+					return nil
+				}
+			} else {
+				hookNames = args
+			}
+
 			// Loop over each hook name and delete it
-			for _, name := range args {
+			for _, name := range hookNames {
 				err := hook.Delete(kubeConfigFlags, name, namespace)
 				if err != nil {
 					return err
@@ -31,6 +52,8 @@ func NewHookCmd(kubeConfigFlags *genericclioptions.ConfigFlags) *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().BoolVar(&all, "all", false, "Delete all migration hooks in the namespace")
 
 	return cmd
 }

--- a/cmd/delete/host.go
+++ b/cmd/delete/host.go
@@ -1,28 +1,49 @@
 package delete
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/yaacov/kubectl-mtv/pkg/cmd/delete/host"
 	"github.com/yaacov/kubectl-mtv/pkg/util/client"
 	"github.com/yaacov/kubectl-mtv/pkg/util/completion"
+	"github.com/yaacov/kubectl-mtv/pkg/util/flags"
 )
 
 // NewHostCmd creates the delete host command
 func NewHostCmd(kubeConfigFlags *genericclioptions.ConfigFlags) *cobra.Command {
+	var all bool
+
 	cmd := &cobra.Command{
-		Use:               "host NAME [NAME...]",
+		Use:               "host [NAME...] [--all]",
 		Short:             "Delete one or more migration hosts",
-		Args:              cobra.MinimumNArgs(1),
+		Args:              flags.ValidateAllFlagArgs(func() bool { return all }, 1),
 		SilenceUsage:      true,
 		ValidArgsFunction: completion.HostResourceNameCompletion(kubeConfigFlags),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Resolve the appropriate namespace based on context and flags
 			namespace := client.ResolveNamespace(kubeConfigFlags)
 
+			var hostNames []string
+			if all {
+				// Get all host names from the namespace
+				var err error
+				hostNames, err = client.GetAllHostNames(kubeConfigFlags, namespace)
+				if err != nil {
+					return fmt.Errorf("failed to get all host names: %v", err)
+				}
+				if len(hostNames) == 0 {
+					fmt.Printf("No hosts found in namespace %s\n", namespace)
+					return nil
+				}
+			} else {
+				hostNames = args
+			}
+
 			// Loop over each host name and delete it
-			for _, name := range args {
+			for _, name := range hostNames {
 				err := host.Delete(kubeConfigFlags, name, namespace)
 				if err != nil {
 					return err
@@ -31,6 +52,8 @@ func NewHostCmd(kubeConfigFlags *genericclioptions.ConfigFlags) *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().BoolVar(&all, "all", false, "Delete all migration hosts in the namespace")
 
 	return cmd
 }

--- a/cmd/delete/plan.go
+++ b/cmd/delete/plan.go
@@ -1,28 +1,49 @@
 package delete
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/yaacov/kubectl-mtv/pkg/cmd/delete/plan"
 	"github.com/yaacov/kubectl-mtv/pkg/util/client"
 	"github.com/yaacov/kubectl-mtv/pkg/util/completion"
+	"github.com/yaacov/kubectl-mtv/pkg/util/flags"
 )
 
 // NewPlanCmd creates the plan deletion command
 func NewPlanCmd(kubeConfigFlags *genericclioptions.ConfigFlags) *cobra.Command {
+	var all bool
+
 	cmd := &cobra.Command{
-		Use:               "plan NAME [NAME...]",
+		Use:               "plan [NAME...] [--all]",
 		Short:             "Delete one or more migration plans",
-		Args:              cobra.MinimumNArgs(1),
+		Args:              flags.ValidateAllFlagArgs(func() bool { return all }, 1),
 		SilenceUsage:      true,
 		ValidArgsFunction: completion.PlanNameCompletion(kubeConfigFlags),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Resolve the appropriate namespace based on context and flags
 			namespace := client.ResolveNamespace(kubeConfigFlags)
 
+			var planNames []string
+			if all {
+				// Get all plan names from the namespace
+				var err error
+				planNames, err = client.GetAllPlanNames(kubeConfigFlags, namespace)
+				if err != nil {
+					return fmt.Errorf("failed to get all plan names: %v", err)
+				}
+				if len(planNames) == 0 {
+					fmt.Printf("No plans found in namespace %s\n", namespace)
+					return nil
+				}
+			} else {
+				planNames = args
+			}
+
 			// Loop over each plan name and delete it
-			for _, name := range args {
+			for _, name := range planNames {
 				err := plan.Delete(kubeConfigFlags, name, namespace)
 				if err != nil {
 					return err
@@ -31,6 +52,8 @@ func NewPlanCmd(kubeConfigFlags *genericclioptions.ConfigFlags) *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().BoolVar(&all, "all", false, "Delete all migration plans in the namespace")
 
 	return cmd
 }

--- a/cmd/delete/provider.go
+++ b/cmd/delete/provider.go
@@ -1,28 +1,49 @@
 package delete
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/yaacov/kubectl-mtv/pkg/cmd/delete/provider"
 	"github.com/yaacov/kubectl-mtv/pkg/util/client"
 	"github.com/yaacov/kubectl-mtv/pkg/util/completion"
+	"github.com/yaacov/kubectl-mtv/pkg/util/flags"
 )
 
 // NewProviderCmd creates the provider deletion command
 func NewProviderCmd(kubeConfigFlags *genericclioptions.ConfigFlags) *cobra.Command {
+	var all bool
+
 	cmd := &cobra.Command{
-		Use:               "provider NAME [NAME...]",
+		Use:               "provider [NAME...] [--all]",
 		Short:             "Delete one or more providers",
-		Args:              cobra.MinimumNArgs(1),
+		Args:              flags.ValidateAllFlagArgs(func() bool { return all }, 1),
 		SilenceUsage:      true,
 		ValidArgsFunction: completion.ProviderNameCompletion(kubeConfigFlags),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Resolve the appropriate namespace based on context and flags
 			namespace := client.ResolveNamespace(kubeConfigFlags)
 
+			var providerNames []string
+			if all {
+				// Get all provider names from the namespace
+				var err error
+				providerNames, err = client.GetAllProviderNames(kubeConfigFlags, namespace)
+				if err != nil {
+					return fmt.Errorf("failed to get all provider names: %v", err)
+				}
+				if len(providerNames) == 0 {
+					fmt.Printf("No providers found in namespace %s\n", namespace)
+					return nil
+				}
+			} else {
+				providerNames = args
+			}
+
 			// Loop over each provider name and delete it
-			for _, name := range args {
+			for _, name := range providerNames {
 				err := provider.Delete(kubeConfigFlags, name, namespace)
 				if err != nil {
 					return err
@@ -31,6 +52,8 @@ func NewProviderCmd(kubeConfigFlags *genericclioptions.ConfigFlags) *cobra.Comma
 			return nil
 		},
 	}
+
+	cmd.Flags().BoolVar(&all, "all", false, "Delete all providers in the namespace")
 
 	return cmd
 }

--- a/cmd/start/plan.go
+++ b/cmd/start/plan.go
@@ -11,16 +11,18 @@ import (
 	"github.com/yaacov/kubectl-mtv/pkg/cmd/start/plan"
 	"github.com/yaacov/kubectl-mtv/pkg/util/client"
 	"github.com/yaacov/kubectl-mtv/pkg/util/completion"
+	"github.com/yaacov/kubectl-mtv/pkg/util/flags"
 )
 
 // NewPlanCmd creates the plan start command
 func NewPlanCmd(kubeConfigFlags *genericclioptions.ConfigFlags, getGlobalConfig func() get.GlobalConfigGetter) *cobra.Command {
 	var cutoverTimeStr string
+	var all bool
 
 	cmd := &cobra.Command{
-		Use:               "plan NAME [NAME...]",
+		Use:               "plan [NAME...] [--all]",
 		Short:             "Start one or more migration plans",
-		Args:              cobra.MinimumNArgs(1),
+		Args:              flags.ValidateAllFlagArgs(func() bool { return all }, 1),
 		SilenceUsage:      true,
 		ValidArgsFunction: completion.PlanNameCompletion(kubeConfigFlags),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -40,8 +42,24 @@ func NewPlanCmd(kubeConfigFlags *genericclioptions.ConfigFlags, getGlobalConfig 
 				cutoverTime = &t
 			}
 
+			var planNames []string
+			if all {
+				// Get all plan names from the namespace
+				var err error
+				planNames, err = client.GetAllPlanNames(config.GetKubeConfigFlags(), namespace)
+				if err != nil {
+					return fmt.Errorf("failed to get all plan names: %v", err)
+				}
+				if len(planNames) == 0 {
+					fmt.Printf("No plans found in namespace %s\n", namespace)
+					return nil
+				}
+			} else {
+				planNames = args
+			}
+
 			// Loop over each plan name and start it
-			for _, name := range args {
+			for _, name := range planNames {
 				err := plan.Start(config.GetKubeConfigFlags(), name, namespace, cutoverTime, config.GetUseUTC())
 				if err != nil {
 					return err
@@ -52,6 +70,7 @@ func NewPlanCmd(kubeConfigFlags *genericclioptions.ConfigFlags, getGlobalConfig 
 	}
 
 	cmd.Flags().StringVarP(&cutoverTimeStr, "cutover", "c", "", "Cutover time in ISO8601 format (e.g., 2023-12-31T15:30:00Z, '$(date -d \"+1 hour\" --iso-8601=sec)' ). If not provided, defaults to 1 hour from now.")
+	cmd.Flags().BoolVar(&all, "all", false, "Start all migration plans in the namespace")
 
 	return cmd
 }

--- a/cmd/unarchive/plan.go
+++ b/cmd/unarchive/plan.go
@@ -1,28 +1,49 @@
 package unarchive
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/yaacov/kubectl-mtv/pkg/cmd/archive/plan"
 	"github.com/yaacov/kubectl-mtv/pkg/util/client"
 	"github.com/yaacov/kubectl-mtv/pkg/util/completion"
+	"github.com/yaacov/kubectl-mtv/pkg/util/flags"
 )
 
 // NewPlanCmd creates the plan unarchive command
 func NewPlanCmd(kubeConfigFlags *genericclioptions.ConfigFlags) *cobra.Command {
+	var all bool
+
 	cmd := &cobra.Command{
-		Use:               "plan NAME [NAME...]",
+		Use:               "plan [NAME...] [--all]",
 		Short:             "Un-archive one or more migration plans",
-		Args:              cobra.MinimumNArgs(1),
+		Args:              flags.ValidateAllFlagArgs(func() bool { return all }, 1),
 		SilenceUsage:      true,
 		ValidArgsFunction: completion.PlanNameCompletion(kubeConfigFlags),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Resolve the appropriate namespace based on context and flags
 			namespace := client.ResolveNamespace(kubeConfigFlags)
 
+			var planNames []string
+			if all {
+				// Get all plan names from the namespace
+				var err error
+				planNames, err = client.GetAllPlanNames(kubeConfigFlags, namespace)
+				if err != nil {
+					return fmt.Errorf("failed to get all plan names: %v", err)
+				}
+				if len(planNames) == 0 {
+					fmt.Printf("No plans found in namespace %s\n", namespace)
+					return nil
+				}
+			} else {
+				planNames = args
+			}
+
 			// Loop over each plan name and unarchive it
-			for _, name := range args {
+			for _, name := range planNames {
 				err := plan.Archive(kubeConfigFlags, name, namespace, false) // Set archived to false for unarchiving
 				if err != nil {
 					return err
@@ -31,5 +52,8 @@ func NewPlanCmd(kubeConfigFlags *genericclioptions.ConfigFlags) *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().BoolVar(&all, "all", false, "Un-archive all migration plans in the namespace")
+
 	return cmd
 }

--- a/pkg/util/client/client.go
+++ b/pkg/util/client/client.go
@@ -1,12 +1,15 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/dynamic"
@@ -148,6 +151,156 @@ func GetAuthenticatedHTTPClient(configFlags *genericclioptions.ConfigFlags, base
 	}
 
 	return NewHTTPClient(baseURL, transport), nil
+}
+
+// GetAllPlanNames retrieves all plan names from the given namespace
+func GetAllPlanNames(configFlags *genericclioptions.ConfigFlags, namespace string) ([]string, error) {
+	dynamicClient, err := GetDynamicClient(configFlags)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dynamic client: %v", err)
+	}
+
+	var planList *unstructured.UnstructuredList
+	if namespace != "" {
+		planList, err = dynamicClient.Resource(PlansGVR).Namespace(namespace).List(context.TODO(), metav1.ListOptions{})
+	} else {
+		planList, err = dynamicClient.Resource(PlansGVR).List(context.TODO(), metav1.ListOptions{})
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to list plans: %v", err)
+	}
+
+	var planNames []string
+	for _, plan := range planList.Items {
+		planNames = append(planNames, plan.GetName())
+	}
+
+	return planNames, nil
+}
+
+// GetAllHookNames retrieves all hook names from the given namespace
+func GetAllHookNames(configFlags *genericclioptions.ConfigFlags, namespace string) ([]string, error) {
+	dynamicClient, err := GetDynamicClient(configFlags)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dynamic client: %v", err)
+	}
+
+	var hookList *unstructured.UnstructuredList
+	if namespace != "" {
+		hookList, err = dynamicClient.Resource(HooksGVR).Namespace(namespace).List(context.TODO(), metav1.ListOptions{})
+	} else {
+		hookList, err = dynamicClient.Resource(HooksGVR).List(context.TODO(), metav1.ListOptions{})
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to list hooks: %v", err)
+	}
+
+	var hookNames []string
+	for _, hook := range hookList.Items {
+		hookNames = append(hookNames, hook.GetName())
+	}
+
+	return hookNames, nil
+}
+
+// GetAllHostNames retrieves all host names from the given namespace
+func GetAllHostNames(configFlags *genericclioptions.ConfigFlags, namespace string) ([]string, error) {
+	dynamicClient, err := GetDynamicClient(configFlags)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dynamic client: %v", err)
+	}
+
+	var hostList *unstructured.UnstructuredList
+	if namespace != "" {
+		hostList, err = dynamicClient.Resource(HostsGVR).Namespace(namespace).List(context.TODO(), metav1.ListOptions{})
+	} else {
+		hostList, err = dynamicClient.Resource(HostsGVR).List(context.TODO(), metav1.ListOptions{})
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to list hosts: %v", err)
+	}
+
+	var hostNames []string
+	for _, host := range hostList.Items {
+		hostNames = append(hostNames, host.GetName())
+	}
+
+	return hostNames, nil
+}
+
+// GetAllProviderNames retrieves all provider names from the given namespace
+func GetAllProviderNames(configFlags *genericclioptions.ConfigFlags, namespace string) ([]string, error) {
+	dynamicClient, err := GetDynamicClient(configFlags)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dynamic client: %v", err)
+	}
+
+	var providerList *unstructured.UnstructuredList
+	if namespace != "" {
+		providerList, err = dynamicClient.Resource(ProvidersGVR).Namespace(namespace).List(context.TODO(), metav1.ListOptions{})
+	} else {
+		providerList, err = dynamicClient.Resource(ProvidersGVR).List(context.TODO(), metav1.ListOptions{})
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to list providers: %v", err)
+	}
+
+	var providerNames []string
+	for _, provider := range providerList.Items {
+		providerNames = append(providerNames, provider.GetName())
+	}
+
+	return providerNames, nil
+}
+
+// GetAllNetworkMappingNames retrieves all network mapping names from the given namespace
+func GetAllNetworkMappingNames(configFlags *genericclioptions.ConfigFlags, namespace string) ([]string, error) {
+	dynamicClient, err := GetDynamicClient(configFlags)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dynamic client: %v", err)
+	}
+
+	var mappingList *unstructured.UnstructuredList
+	if namespace != "" {
+		mappingList, err = dynamicClient.Resource(NetworkMapGVR).Namespace(namespace).List(context.TODO(), metav1.ListOptions{})
+	} else {
+		mappingList, err = dynamicClient.Resource(NetworkMapGVR).List(context.TODO(), metav1.ListOptions{})
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to list network mappings: %v", err)
+	}
+
+	var mappingNames []string
+	for _, mapping := range mappingList.Items {
+		mappingNames = append(mappingNames, mapping.GetName())
+	}
+
+	return mappingNames, nil
+}
+
+// GetAllStorageMappingNames retrieves all storage mapping names from the given namespace
+func GetAllStorageMappingNames(configFlags *genericclioptions.ConfigFlags, namespace string) ([]string, error) {
+	dynamicClient, err := GetDynamicClient(configFlags)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dynamic client: %v", err)
+	}
+
+	var mappingList *unstructured.UnstructuredList
+	if namespace != "" {
+		mappingList, err = dynamicClient.Resource(StorageMapGVR).Namespace(namespace).List(context.TODO(), metav1.ListOptions{})
+	} else {
+		mappingList, err = dynamicClient.Resource(StorageMapGVR).List(context.TODO(), metav1.ListOptions{})
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to list storage mappings: %v", err)
+	}
+
+	var mappingNames []string
+	for _, mapping := range mappingList.Items {
+		mappingNames = append(mappingNames, mapping.GetName())
+	}
+
+	return mappingNames, nil
 }
 
 // HTTPClient represents a client for making HTTP requests with authentication

--- a/pkg/util/flags/validation.go
+++ b/pkg/util/flags/validation.go
@@ -1,0 +1,23 @@
+package flags
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// ValidateAllFlagArgs validates arguments when --all flag is used.
+// getAllFlagValue should return the current value of the --all flag.
+// When the flag is true, no arguments should be provided.
+// When the flag is false, at least minArgs arguments should be provided.
+func ValidateAllFlagArgs(getAllFlagValue func() bool, minArgs int) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if getAllFlagValue() {
+			if len(args) > 0 {
+				return fmt.Errorf("cannot specify resource names when using --all flag")
+			}
+			return nil
+		}
+		return cobra.MinimumNArgs(minArgs)(cmd, args)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a --all flag to bulk-manage resources in a namespace: plans (archive, unarchive, start, cutover, delete), hooks, hosts, providers, and network/storage mappings.
  * Commands now accept either specific names or --all, with usage updated to: [NAME...] [--all].
  * Graceful handling when no matching resources exist, with informative messages.

* **Documentation**
  * Updated command help and usage text to reflect the new --all option and argument rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->