### PR TITLE
bumpb

### DIFF
--- a/kubectl-mtv.spec
+++ b/kubectl-mtv.spec
@@ -9,7 +9,7 @@
 %define debug_package %{nil}
 
 Name:           %{repo}
-Version:        0.1.29
+Version:        0.1.30
 Release:        1%{?dist}
 Summary:        kubectl-mtv - Migration Toolkit for Virtualization CLI
 License:        Apache

--- a/mcp/kubev2v/kubectl_mtv_write_server.py
+++ b/mcp/kubev2v/kubectl_mtv_write_server.py
@@ -576,12 +576,12 @@ async def ManageMapping(
     Storage pairs: 'source:storage-class[;volumeMode=Block|Filesystem][;accessMode=ReadWriteOnce|ReadWriteMany|ReadOnlyMany][;offloadPlugin=vsphere][;offloadSecret=secret-name][;offloadVendor=vantara|ontap|...]' (comma-separated pairs, semicolon-separated parameters)
     Special values: 'source:default' (pod networking), 'source:ignored' (skip network)
     Multiple pairs: comma-separated 'pair1,pair2,pair3'
-    
+
     Network Mapping Constraints:
     - All source networks must be mapped (no source networks can be left unmapped)
     - Pod networking and specific multus targets can only be mapped once (no duplicate targets)
     - Use 'source:ignored' to map networks that don't have suitable targets or are not needed
-    
+
     Storage Mapping Constraints:
     - All source storages must be mapped (no source storages can be left unmapped)
     - Preferred storage classes have virt annotation, k8s annotation, or "virtualization" in name
@@ -622,7 +622,7 @@ async def ManageMapping(
                      source_provider="vsphere-provider", target_provider="openshift-provider",
                      pairs="fast-datastore:ocs-storagecluster-ceph-rbd;volumeMode=Block;accessMode=ReadWriteOnce;offloadPlugin=vsphere;offloadVendor=vantara",
                      default_volume_mode="Block")
-        
+
         # Auto-selection will prioritize storage classes with these annotations:
         # 1. storageclass.kubevirt.io/is-default-virt-class=true (preferred for virtualization)
         # 2. storageclass.kubernetes.io/is-default-class=true (Kubernetes default)
@@ -907,7 +907,12 @@ async def CreatePlan(
         network_mapping: Name of existing network mapping to use (optional, auto-created if not provided)
         storage_mapping: Name of existing storage mapping to use (optional, auto-created if not provided)
         network_pairs: Network mapping pairs - 'source:target-namespace/target-network' format (optional, creates mapping if provided). Note: All source networks must be mapped, pod/multus targets can only be used once, use 'source:ignored' for unmappable networks
-        storage_pairs: Storage mapping pairs in enhanced format 'source:storage-class[;volumeMode=Block|Filesystem][;accessMode=ReadWriteOnce|ReadWriteMany|ReadOnlyMany][;offloadPlugin=vsphere][;offloadSecret=secret-name][;offloadVendor=vantara|ontap|...]' (optional, creates mapping if provided). Note: All source storages must be mapped, auto-selection uses storageclass.kubevirt.io/is-default-virt-class > storageclass.kubernetes.io/is-default-class > name with "virtualization"
+        storage_pairs: Storage mapping pairs in enhanced format (optional, creates mapping if provided):
+            'source:storage-class[;volumeMode=Block|Filesystem][;accessMode=ReadWriteOnce|ReadWriteMany|ReadOnlyMany]
+            [;offloadPlugin=vsphere][;offloadSecret=secret-name][;offloadVendor=vantara|ontap|...]'
+            Note: All source storages must be mapped, auto-selection uses
+            storageclass.kubevirt.io/is-default-virt-class > storageclass.kubernetes.io/is-default-class >
+            name with "virtualization"
         vms: VM names (comma-separated) or @filename for YAML/JSON file with VM structures (optional)
         pre_hook: Pre-migration hook to add to all VMs (optional)
         post_hook: Post-migration hook to add to all VMs (optional)

--- a/mcp/requirements-dev.txt
+++ b/mcp/requirements-dev.txt
@@ -1,3 +1,7 @@
 # Development requirements for linting and formatting
 flake8>=6.0.0
 black>=23.0.0
+
+# Build and packaging requirements
+build>=0.10.0
+twine>=4.0.0

--- a/mcp/setup.py
+++ b/mcp/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name="mtv-mcp",
-    version="1.0.4",
+    version="1.0.5",
     description="MCP Servers for kubectl-mtv - Migration Toolkit for Virtualization",
     author="kubectl-mtv MCP Server",
     packages=find_namespace_packages(include=["kubev2v*"]),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Bumped package versions for new builds: kubectl-mtv 0.1.29 → 0.1.30; MCP 1.0.4 → 1.0.5.
  - Added build/packaging dev dependencies (build, twine) to developer requirements.

- Documentation
  - Improved and reformatted user-facing documentation for two management commands, clarifying storage/network mapping examples and notes.

- Notes
  - No runtime, API, or behavior changes; existing workflows unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->