### PR TITLE
update-namesapce

### DIFF
--- a/pkg/cmd/create/mapping/network.go
+++ b/pkg/cmd/create/mapping/network.go
@@ -76,9 +76,13 @@ func parseNetworkPairs(pairStr, defaultNamespace string, configFlags *genericcli
 		if targetName != "" {
 			destinationNetwork.Name = targetName
 		}
-		// Only set namespace if it's different from the default namespace (plan namespace)
-		if targetNamespace != "" && targetNamespace != defaultNamespace {
-			destinationNetwork.Namespace = targetNamespace
+		// Always set namespace for multus networks, use plan namespace if empty
+		if targetType == "multus" {
+			if targetNamespace != "" {
+				destinationNetwork.Namespace = targetNamespace
+			} else {
+				destinationNetwork.Namespace = defaultNamespace
+			}
 		}
 
 		// Create a pair for each matching source network resource

--- a/pkg/cmd/create/plan/network/fetchers/openshift/fetcher.go
+++ b/pkg/cmd/create/plan/network/fetchers/openshift/fetcher.go
@@ -206,15 +206,17 @@ func (f *OpenShiftNetworkFetcher) FetchTargetNetworks(configFlags *genericcliopt
 		}
 
 		// For OpenShift targets, create Multus network reference
-		// Only include namespace if it's different from the current namespace (plan namespace)
+		// Always set namespace, use plan namespace if empty
 		klog.V(4).Infof("Creating multus network reference for: %s/%s", networkNamespace, networkName)
 		destNetwork := forkliftv1beta1.DestinationNetwork{
 			Type: "multus",
 			Name: networkName,
 		}
-		// Only set namespace if it's not empty and different from the current namespace (plan namespace)
-		if networkNamespace != "" && networkNamespace != namespace {
+		// Always set namespace, use plan namespace if empty
+		if networkNamespace != "" {
 			destNetwork.Namespace = networkNamespace
+		} else {
+			destNetwork.Namespace = namespace
 		}
 		targetNetworks = append(targetNetworks, destNetwork)
 	}

--- a/pkg/cmd/create/plan/network/mapper/mapper.go
+++ b/pkg/cmd/create/plan/network/mapper/mapper.go
@@ -68,19 +68,21 @@ func parseDefaultNetwork(defaultTargetNetwork, namespace string) forkliftv1beta1
 			Type: "multus",
 			Name: parts[1],
 		}
-		// Only set namespace if it's not empty and different from the plan namespace
-		if parts[0] != "" && parts[0] != namespace {
+		// Always set namespace, use plan namespace if empty
+		if parts[0] != "" {
 			destNetwork.Namespace = parts[0]
+		} else {
+			destNetwork.Namespace = namespace
 		}
 		return destNetwork
 	}
 
-	// Just a name, use the provided namespace (but only if not the same as plan namespace)
+	// Just a name, use the plan namespace
 	destNetwork := forkliftv1beta1.DestinationNetwork{
-		Type: "multus",
-		Name: defaultTargetNetwork,
+		Type:      "multus",
+		Name:      defaultTargetNetwork,
+		Namespace: namespace,
 	}
-	// Since we're using the provided namespace and it's the same as plan namespace, don't set it
 	return destNetwork
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Target networks now always include a namespace across creation, mapping, and OpenShift fetching (including Multus).
  * Uses the provided network namespace when set; otherwise falls back to the plan/default namespace.
  * Handles edge cases like “/name” to prevent missing namespaces.
  * Improves reliability of plan creation and network pairing, reducing failures from unset namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->