### PR TITLE
fix mcp explicit patch boolean values

### DIFF
--- a/docs/README-usage.md
+++ b/docs/README-usage.md
@@ -174,7 +174,7 @@ kubectl mtv patch provider openshift-provider \
 # Update VDDK settings for vSphere
 kubectl mtv patch provider vsphere-provider \
   --vddk-init-image registry.example.com/vddk:v8.0.2 \
-  --use-vddk-aio-optimization=true
+  --use-vddk-aio-optimization
 
 # Update OpenStack credentials
 kubectl mtv patch provider openstack-provider \
@@ -206,7 +206,11 @@ Update migration plan configuration without changing providers, mappings, or VMs
 kubectl mtv patch plan my-migration-plan \
   --migration-type warm \
   --target-namespace production \
-  --use-compatibility-mode=true
+  --use-compatibility-mode
+
+# Disable compatibility mode for modern VMs with native drivers
+kubectl mtv patch plan modern-migration \
+  --use-compatibility-mode=false
 
 # Configure transfer network (supports namespace/name syntax)
 kubectl mtv patch plan my-plan \
@@ -229,7 +233,7 @@ kubectl mtv patch plan my-plan \
 kubectl mtv patch plan production-plan \
   --description "Production migration batch 1" \
   --pvc-name-template "prod-{{.VmName}}-disk{{.DiskIndex}}" \
-  --preserve-static-ips=true
+  --preserve-static-ips
 ```
 
 #### Patch Individual VMs

--- a/docs/README_patch_plans.md
+++ b/docs/README_patch_plans.md
@@ -58,7 +58,7 @@ kubectl-mtv patch plan my-migration-plan \
 
 # Enable compatibility mode
 kubectl-mtv patch plan legacy-systems \
-  --use-compatibility-mode=true \
+  --use-compatibility-mode \
   --install-legacy-drivers=true
 ```
 
@@ -116,20 +116,20 @@ kubectl-mtv patch plan production-migration \
 
 # Configure vSphere-specific settings
 kubectl-mtv patch plan vsphere-migration \
-  --preserve-static-ips=true \
-  --preserve-cluster-cpu-model=true
+  --preserve-static-ips \
+  --preserve-cluster-cpu-model
 
 # Configure oVirt-specific settings  
 kubectl-mtv patch plan ovirt-migration \
-  --preserve-cluster-cpu-model=true \
+  --preserve-cluster-cpu-model \
   --migrate-shared-disks=false
 
 # Set plan metadata and behavior
 kubectl-mtv patch plan legacy-app-migration \
   --description "Legacy application migration - batch 2" \
-  --skip-guest-conversion=true \
-  --use-compatibility-mode=true \
-  --delete-guest-conversion-pod=true
+  --skip-guest-conversion \
+  --use-compatibility-mode \
+  --delete-guest-conversion-pod
 ```
 
 #### Configure PVC and Storage Settings
@@ -142,13 +142,13 @@ kubectl-mtv patch plan storage-migration \
 
 # Archive completed plans
 kubectl-mtv patch plan completed-migration \
-  --archived=true \
+  --archived \
   --description "Completed migration - archived for records"
 
 # Configure power management and failure handling
 kubectl-mtv patch plan production-migration \
   --target-power-state on \
-  --delete-vm-on-fail-migration=true \
+  --delete-vm-on-fail-migration \
   --description "Production migration with automatic cleanup on failure"
 ```
 
@@ -468,6 +468,11 @@ kubectl-mtv patch planvm active-migration problematic-vm \
 kubectl-mtv patch plan next-batch \
   --target-labels "env=production,migration-batch=2,validated=true" \
   --use-compatibility-mode=false
+
+# Disable compatibility mode for modern VMs that don't need it
+kubectl-mtv patch plan modern-migration \
+  --use-compatibility-mode=false \
+  --description "Modern VMs with native drivers"
 ```
 
 ## Troubleshooting

--- a/docs/README_patch_providers.md
+++ b/docs/README_patch_providers.md
@@ -89,7 +89,7 @@ kubectl-mtv patch provider openstack-provider \
 # Update vSphere provider VDDK configuration
 kubectl-mtv patch provider vsphere-provider \
   --vddk-init-image registry.example.com/vddk:v8.0.2 \
-  --use-vddk-aio-optimization=true
+  --use-vddk-aio-optimization
 
 # Update VDDK buffer settings for performance tuning
 kubectl-mtv patch provider vsphere-provider \
@@ -106,7 +106,7 @@ kubectl-mtv patch provider vsphere-provider \
   --username newadmin@vsphere.local \
   --password newpassword \
   --vddk-init-image registry.example.com/vddk:latest \
-  --use-vddk-aio-optimization=true
+  --use-vddk-aio-optimization
 ```
 
 ## Secret Ownership and Security
@@ -198,7 +198,7 @@ The patch command respects the same environment variables as create:
 ```bash
 # Set default VDDK init image
 export MTV_VDDK_INIT_IMAGE=registry.example.com/vddk:v8.0.2
-kubectl-mtv patch provider vsphere-provider --use-vddk-aio-optimization=true
+kubectl-mtv patch provider vsphere-provider --use-vddk-aio-optimization
 ```
 
 ## Best Practices

--- a/mcp/setup.py
+++ b/mcp/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         "fastmcp>=2.11.0.9",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.10",
     entry_points={
         "console_scripts": [
             "kubectl-mtv-mcp=kubev2v.kubectl_mtv_server:mcp.run",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI booleans are now presence-based toggles: add --flag to enable, use --flag=false to disable, or omit to leave unchanged.
  * Plan lifecycle gained archive/unarchive actions and start now accepts multiple plan names.

* **Documentation**
  * Updated usage and plan examples to replace “=true” with bare flags and added a new example demonstrating explicit disable.

* **Bug Fixes**
  * Validation added to prevent invalid storage settings for conversion migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->