### PR TITLE
ignore-as-default-target

### DIFF
--- a/pkg/cmd/create/plan/network/mapper/mapper.go
+++ b/pkg/cmd/create/plan/network/mapper/mapper.go
@@ -62,6 +62,10 @@ func parseDefaultNetwork(defaultTargetNetwork, namespace string) forkliftv1beta1
 		return forkliftv1beta1.DestinationNetwork{Type: "pod"}
 	}
 
+	if defaultTargetNetwork == "ignored" {
+		return forkliftv1beta1.DestinationNetwork{Type: "ignored"}
+	}
+
 	// Handle "namespace/name" format for multus networks
 	if parts := strings.Split(defaultTargetNetwork, "/"); len(parts) == 2 {
 		destNetwork := forkliftv1beta1.DestinationNetwork{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for selecting “Ignored” as the default target network when creating network mappings. This lets you exclude networks from the destination by default.
  - When “Ignored” is set as the default, the initial source network and any additional unmapped source networks will map to “Ignored,” simplifying scenarios where destination networking should be omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->