### PR TITLE
add ns to source net if exsit

### DIFF
--- a/pkg/cmd/create/plan/network/fetchers/openshift/fetcher.go
+++ b/pkg/cmd/create/plan/network/fetchers/openshift/fetcher.go
@@ -147,6 +147,9 @@ func (f *OpenShiftNetworkFetcher) FetchSourceNetworks(configFlags *genericcliopt
 			if name, ok := networkItem["name"].(string); ok {
 				sourceNetwork.Name = name
 			}
+			if namespace, ok := networkItem["namespace"].(string); ok {
+				sourceNetwork.Namespace = namespace
+			}
 			sourceNetworks = append(sourceNetworks, sourceNetwork)
 		}
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Source networks fetched from OpenShift now include the namespace when available, improving data completeness and accuracy.
  * Reduces ambiguity for networks with identical names across namespaces, aiding clearer selection during planning.
  * Helps prevent mismatches and minimizes manual corrections in mapping workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->