### PR TITLE
validate network mappings for duplications

### DIFF
--- a/mcp/kubev2v/kubevirt_server.py
+++ b/mcp/kubev2v/kubevirt_server.py
@@ -2188,7 +2188,9 @@ Examples:
     )
 
     # Keep legacy args for backward compatibility
-    parser.add_argument("--name", default="kubevirt", help="Server name (legacy, ignored)")
+    parser.add_argument(
+        "--name", default="kubevirt", help="Server name (legacy, ignored)"
+    )
     parser.add_argument("--version", help="Server version (legacy, ignored)")
 
     return parser.parse_args()

--- a/mcp/setup.py
+++ b/mcp/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name="mtv-mcp",
-    version="1.0.15",
+    version="1.0.16",
     description="MCP Servers for kubectl-mtv - Migration Toolkit for Virtualization",
     author="kubectl-mtv MCP Server",
     packages=find_namespace_packages(include=["kubev2v*"]),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added validation for network mapping pairs to prevent duplicate target networks across sources. Pod network (“default”) and specific NADs can be mapped only once; “ignored” may repeat. Clear, actionable error messages guide remediation.
* Documentation
  * Updated network mapping and CreatePlan docs with explicit rules, examples of valid/invalid combinations, and usage of source:ignored.
* Style
  * Minor formatting cleanup for a CLI flag; no behavioral changes.
* Chores
  * Bumped package version to 1.0.16.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->