### PR TITLE
add namespace to mappings

### DIFF
--- a/pkg/cmd/create/mapping/storage.go
+++ b/pkg/cmd/create/mapping/storage.go
@@ -238,6 +238,10 @@ func createStorageMappingWithOptions(ctx context.Context, configFlags *genericcl
 		return fmt.Errorf("failed to get client: %v", err)
 	}
 
+	// Parse provider references to extract names and namespaces
+	sourceProviderName, sourceProviderNamespace := parseProviderReference(sourceProvider, namespace)
+	targetProviderName, targetProviderNamespace := parseProviderReference(targetProvider, namespace)
+
 	// Parse storage pairs if provided
 	var mappingPairs []forkliftv1beta1.StoragePair
 	if storagePairs != "" {
@@ -256,12 +260,12 @@ func createStorageMappingWithOptions(ctx context.Context, configFlags *genericcl
 		Spec: forkliftv1beta1.StorageMapSpec{
 			Provider: provider.Pair{
 				Source: corev1.ObjectReference{
-					Name:      sourceProvider,
-					Namespace: namespace,
+					Name:      sourceProviderName,
+					Namespace: sourceProviderNamespace,
 				},
 				Destination: corev1.ObjectReference{
-					Name:      targetProvider,
-					Namespace: namespace,
+					Name:      targetProviderName,
+					Namespace: targetProviderNamespace,
 				},
 			},
 			Map: mappingPairs,

--- a/pkg/cmd/create/plan/network/factory.go
+++ b/pkg/cmd/create/plan/network/factory.go
@@ -136,10 +136,7 @@ func CreateNetworkMap(ctx context.Context, opts NetworkMapperOptions) (string, e
 		opts.SourceProvider, opts.TargetProvider, opts.DefaultTargetNetwork)
 
 	// Get source network fetcher using the provider's namespace
-	sourceProviderNamespace := opts.SourceProviderNamespace
-	if sourceProviderNamespace == "" {
-		sourceProviderNamespace = opts.Namespace
-	}
+	sourceProviderNamespace := client.GetProviderNamespace(opts.SourceProviderNamespace, opts.Namespace)
 	sourceFetcher, err := GetSourceNetworkFetcher(ctx, opts.ConfigFlags, opts.SourceProvider, sourceProviderNamespace)
 	if err != nil {
 		return "", fmt.Errorf("failed to get source network fetcher: %v", err)
@@ -147,10 +144,7 @@ func CreateNetworkMap(ctx context.Context, opts NetworkMapperOptions) (string, e
 	klog.V(4).Infof("DEBUG: Source fetcher created for provider: %s", opts.SourceProvider)
 
 	// Get target network fetcher using the provider's namespace
-	targetProviderNamespace := opts.TargetProviderNamespace
-	if targetProviderNamespace == "" {
-		targetProviderNamespace = opts.Namespace
-	}
+	targetProviderNamespace := client.GetProviderNamespace(opts.TargetProviderNamespace, opts.Namespace)
 	targetFetcher, err := GetTargetNetworkFetcher(ctx, opts.ConfigFlags, opts.TargetProvider, targetProviderNamespace)
 	if err != nil {
 		return "", fmt.Errorf("failed to get target network fetcher: %v", err)
@@ -223,13 +217,13 @@ func createNetworkMap(opts NetworkMapperOptions, networkPairs []forkliftv1beta1.
 					Kind:       "Provider",
 					APIVersion: forkliftv1beta1.SchemeGroupVersion.String(),
 					Name:       opts.SourceProvider,
-					Namespace:  opts.Namespace,
+					Namespace:  client.GetProviderNamespace(opts.SourceProviderNamespace, opts.Namespace),
 				},
 				Destination: corev1.ObjectReference{
 					Kind:       "Provider",
 					APIVersion: forkliftv1beta1.SchemeGroupVersion.String(),
 					Name:       opts.TargetProvider,
-					Namespace:  opts.Namespace,
+					Namespace:  client.GetProviderNamespace(opts.TargetProviderNamespace, opts.Namespace),
 				},
 			},
 			Map: networkPairs,

--- a/pkg/cmd/create/plan/storage/factory.go
+++ b/pkg/cmd/create/plan/storage/factory.go
@@ -58,10 +58,7 @@ func CreateStorageMap(ctx context.Context, opts StorageMapperOptions) (string, e
 		opts.SourceProvider, opts.TargetProvider, opts.DefaultTargetStorageClass)
 
 	// Get source storage fetcher using the provider's namespace
-	sourceProviderNamespace := opts.SourceProviderNamespace
-	if sourceProviderNamespace == "" {
-		sourceProviderNamespace = opts.Namespace
-	}
+	sourceProviderNamespace := client.GetProviderNamespace(opts.SourceProviderNamespace, opts.Namespace)
 	sourceFetcher, err := GetSourceStorageFetcher(ctx, opts.ConfigFlags, opts.SourceProvider, sourceProviderNamespace)
 	if err != nil {
 		return "", fmt.Errorf("failed to get source storage fetcher: %v", err)
@@ -69,10 +66,7 @@ func CreateStorageMap(ctx context.Context, opts StorageMapperOptions) (string, e
 	klog.V(4).Infof("DEBUG: Source storage fetcher created for provider: %s", opts.SourceProvider)
 
 	// Get target storage fetcher using the provider's namespace
-	targetProviderNamespace := opts.TargetProviderNamespace
-	if targetProviderNamespace == "" {
-		targetProviderNamespace = opts.Namespace
-	}
+	targetProviderNamespace := client.GetProviderNamespace(opts.TargetProviderNamespace, opts.Namespace)
 	targetFetcher, err := GetTargetStorageFetcher(ctx, opts.ConfigFlags, opts.TargetProvider, targetProviderNamespace)
 	if err != nil {
 		return "", fmt.Errorf("failed to get target storage fetcher: %v", err)
@@ -144,13 +138,13 @@ func createStorageMap(opts StorageMapperOptions, storagePairs []forkliftv1beta1.
 					Kind:       "Provider",
 					APIVersion: forkliftv1beta1.SchemeGroupVersion.String(),
 					Name:       opts.SourceProvider,
-					Namespace:  opts.Namespace,
+					Namespace:  client.GetProviderNamespace(opts.SourceProviderNamespace, opts.Namespace),
 				},
 				Destination: corev1.ObjectReference{
 					Kind:       "Provider",
 					APIVersion: forkliftv1beta1.SchemeGroupVersion.String(),
 					Name:       opts.TargetProvider,
-					Namespace:  opts.Namespace,
+					Namespace:  client.GetProviderNamespace(opts.TargetProviderNamespace, opts.Namespace),
 				},
 			},
 			Map: storagePairs,

--- a/pkg/util/client/namespace.go
+++ b/pkg/util/client/namespace.go
@@ -39,3 +39,13 @@ func ResolveNamespaceWithAllFlag(configFlags *genericclioptions.ConfigFlags, all
 	}
 	return ResolveNamespace(configFlags)
 }
+
+// GetProviderNamespace returns the provider namespace, falling back to default if empty.
+// This is commonly used when provider namespaces may be unspecified and should default
+// to the same namespace as the resource being created.
+func GetProviderNamespace(providerNamespace, defaultNamespace string) string {
+	if providerNamespace != "" {
+		return providerNamespace
+	}
+	return defaultNamespace
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - You can now specify provider references as “namespace/name” or just “name” when creating network and storage mappings; whitespace is handled.
  - Source and target provider namespaces can be set independently per reference; if omitted, the default/selected namespace is used.
  - Improved, consistent namespace resolution when creating network/storage plans and maps for clearer, predictable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->