### PR TITLE
dry-run

### DIFF
--- a/cmd/create/hook.go
+++ b/cmd/create/hook.go
@@ -19,6 +19,8 @@ func NewHookCmd(kubeConfigFlags *genericclioptions.ConfigFlags) *cobra.Command {
 	var serviceAccount string
 	var playbook string
 	var deadline int64
+	var dryRun bool
+	var outputFormat string
 
 	// HookSpec fields
 	var hookSpec forkliftv1beta1.HookSpec
@@ -76,11 +78,24 @@ Examples:
 				hookSpec.Deadline = deadline
 			}
 
+			if !dryRun && outputFormat != "" {
+				return fmt.Errorf("--output flag can only be used with --dry-run")
+			}
+			if dryRun && outputFormat != "" && outputFormat != "json" && outputFormat != "yaml" {
+				return fmt.Errorf("invalid output format for dry-run: %s. Valid formats are: json, yaml", outputFormat)
+			}
+			resolvedFormat := outputFormat
+			if dryRun && resolvedFormat == "" {
+				resolvedFormat = "yaml"
+			}
+
 			opts := hook.CreateHookOptions{
-				Name:        name,
-				Namespace:   namespace,
-				ConfigFlags: kubeConfigFlags,
-				HookSpec:    hookSpec,
+				Name:         name,
+				Namespace:    namespace,
+				ConfigFlags:  kubeConfigFlags,
+				HookSpec:     hookSpec,
+				DryRun:       dryRun,
+				OutputFormat: resolvedFormat,
 			}
 
 			return hook.Create(opts)
@@ -92,6 +107,8 @@ Examples:
 	cmd.Flags().StringVar(&serviceAccount, "service-account", "", "Service account to use for the hook (optional)")
 	cmd.Flags().StringVar(&playbook, "playbook", "", "Ansible playbook content, or use @filename to read from file (optional)")
 	cmd.Flags().Int64Var(&deadline, "deadline", 0, "Hook deadline in seconds (optional)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Output Hook CR to stdout instead of creating it")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format for dry-run (json, yaml). Defaults to yaml when --dry-run is used")
 
 	if err := cmd.MarkFlagRequired("name"); err != nil {
 		panic(err)

--- a/cmd/create/host.go
+++ b/cmd/create/host.go
@@ -24,6 +24,8 @@ func NewHostCmd(kubeConfigFlags *genericclioptions.ConfigFlags, globalConfig Glo
 	var networkAdapterName string
 	var hostInsecureSkipTLS bool
 	var cacert string
+	var dryRun bool
+	var outputFormat string
 
 	// HostSpec fields
 	var hostSpec forkliftv1beta1.HostSpec
@@ -105,6 +107,17 @@ Examples:
 				cacert = string(fileContent)
 			}
 
+			if !dryRun && outputFormat != "" {
+				return fmt.Errorf("--output flag can only be used with --dry-run")
+			}
+			if dryRun && outputFormat != "" && outputFormat != "json" && outputFormat != "yaml" {
+				return fmt.Errorf("invalid output format for dry-run: %s. Valid formats are: json, yaml", outputFormat)
+			}
+			resolvedFormat := outputFormat
+			if dryRun && resolvedFormat == "" {
+				resolvedFormat = "yaml"
+			}
+
 			opts := host.CreateHostOptions{
 				HostIDs:                  hostIDs,
 				Namespace:                namespace,
@@ -120,6 +133,8 @@ Examples:
 				HostInsecureSkipTLS:      hostInsecureSkipTLS,
 				CACert:                   cacert,
 				HostSpec:                 hostSpec,
+				DryRun:                   dryRun,
+				OutputFormat:             resolvedFormat,
 			}
 
 			return host.Create(cmd.Context(), opts)
@@ -137,6 +152,8 @@ Examples:
 	cmd.Flags().StringVar(&networkAdapterName, "network-adapter", "", "Network adapter name to get IP address from inventory (required - mutually exclusive with --ip-address)")
 	cmd.Flags().BoolVar(&hostInsecureSkipTLS, "host-insecure-skip-tls", false, "Skip TLS verification when connecting to the host (only used when creating new secret)")
 	cmd.Flags().StringVar(&cacert, "cacert", "", "CA certificate for host authentication - provide certificate content directly or use @filename to load from file (only used when creating new secret)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Output Host CR(s) to stdout instead of creating them")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format for dry-run (json, yaml). Defaults to yaml when --dry-run is used")
 
 	if err := cmd.MarkFlagRequired("host-id"); err != nil {
 		panic(err)

--- a/cmd/create/mapping.go
+++ b/cmd/create/mapping.go
@@ -36,6 +36,8 @@ create specific mapping types.`,
 func newNetworkMappingCmd(kubeConfigFlags *genericclioptions.ConfigFlags, globalConfig GlobalConfigGetter) *cobra.Command {
 	var name, sourceProvider, targetProvider string
 	var networkPairs string
+	var dryRun bool
+	var outputFormat string
 
 	cmd := &cobra.Command{
 		Use:   "network",
@@ -78,7 +80,17 @@ Pair formats:
 			inventoryURL := globalConfig.GetInventoryURL()
 			inventoryInsecureSkipTLS := globalConfig.GetInventoryInsecureSkipTLS()
 
-			return mapping.CreateNetworkWithInsecure(kubeConfigFlags, name, namespace, sourceProvider, targetProvider, networkPairs, inventoryURL, inventoryInsecureSkipTLS)
+			if !dryRun && outputFormat != "" {
+				return fmt.Errorf("--output flag can only be used with --dry-run")
+			}
+			if dryRun && outputFormat != "" && outputFormat != "json" && outputFormat != "yaml" {
+				return fmt.Errorf("invalid output format for dry-run: %s. Valid formats are: json, yaml", outputFormat)
+			}
+			if dryRun && outputFormat == "" {
+				outputFormat = "yaml"
+			}
+
+			return mapping.CreateNetworkWithInsecure(kubeConfigFlags, name, namespace, sourceProvider, targetProvider, networkPairs, inventoryURL, inventoryInsecureSkipTLS, dryRun, outputFormat)
 		},
 	}
 
@@ -86,6 +98,8 @@ Pair formats:
 	cmd.Flags().StringVarP(&sourceProvider, "source", "S", "", "Source provider name")
 	cmd.Flags().StringVarP(&targetProvider, "target", "T", "", "Target provider name")
 	cmd.Flags().StringVar(&networkPairs, "network-pairs", "", "Network mapping pairs in format 'source:target-namespace/target-network', 'source:target-network', 'source:default', or 'source:ignored' (comma-separated)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Output mapping CR to stdout instead of creating it")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format for dry-run (json, yaml). Defaults to yaml when --dry-run is used")
 
 	_ = cmd.RegisterFlagCompletionFunc("source", completion.ProviderNameCompletion(kubeConfigFlags))
 	_ = cmd.RegisterFlagCompletionFunc("target", completion.ProviderNameCompletion(kubeConfigFlags))
@@ -110,6 +124,8 @@ func newStorageMappingCmd(kubeConfigFlags *genericclioptions.ConfigFlags, global
 	var offloadStorageUsername, offloadStoragePassword, offloadStorageEndpoint string
 	var offloadCACert string
 	var offloadInsecureSkipTLS bool
+	var dryRun bool
+	var outputFormat string
 
 	cmd := &cobra.Command{
 		Use:   "storage",
@@ -154,6 +170,16 @@ plugin configuration for optimized data transfer.`,
 			inventoryURL := globalConfig.GetInventoryURL()
 			inventoryInsecureSkipTLS := globalConfig.GetInventoryInsecureSkipTLS()
 
+			if !dryRun && outputFormat != "" {
+				return fmt.Errorf("--output flag can only be used with --dry-run")
+			}
+			if dryRun && outputFormat != "" && outputFormat != "json" && outputFormat != "yaml" {
+				return fmt.Errorf("invalid output format for dry-run: %s. Valid formats are: json, yaml", outputFormat)
+			}
+			if dryRun && outputFormat == "" {
+				outputFormat = "yaml"
+			}
+
 			return mapping.CreateStorageWithOptions(mapping.StorageCreateOptions{
 				ConfigFlags:              kubeConfigFlags,
 				Name:                     name,
@@ -177,6 +203,8 @@ plugin configuration for optimized data transfer.`,
 				OffloadStorageEndpoint: offloadStorageEndpoint,
 				OffloadCACert:          offloadCACert,
 				OffloadInsecureSkipTLS: offloadInsecureSkipTLS,
+				DryRun:                 dryRun,
+				OutputFormat:           outputFormat,
 			})
 		},
 	}
@@ -200,6 +228,8 @@ plugin configuration for optimized data transfer.`,
 	cmd.Flags().StringVar(&offloadStorageEndpoint, "offload-storage-endpoint", "", "Storage array management endpoint URL for offload secret")
 	cmd.Flags().StringVar(&offloadCACert, "offload-cacert", "", "CA certificate for offload secret (use @filename to load from file)")
 	cmd.Flags().BoolVar(&offloadInsecureSkipTLS, "offload-insecure-skip-tls", false, "Skip TLS verification for offload connections")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Output mapping CR to stdout instead of creating it")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format for dry-run (json, yaml). Defaults to yaml when --dry-run is used")
 
 	_ = cmd.RegisterFlagCompletionFunc("source", completion.ProviderNameCompletion(kubeConfigFlags))
 	_ = cmd.RegisterFlagCompletionFunc("target", completion.ProviderNameCompletion(kubeConfigFlags))

--- a/cmd/create/plan.go
+++ b/cmd/create/plan.go
@@ -85,6 +85,9 @@ func NewPlanCmd(kubeConfigFlags *genericclioptions.ConfigFlags, globalConfig Glo
 	var convertorNodeSelector []string
 	var convertorAffinity string
 
+	var dryRun bool
+	var outputFormat string
+
 	cmd := &cobra.Command{
 		Use:   "plan",
 		Short: "Create a migration plan",
@@ -469,6 +472,17 @@ Affinity Syntax (KARL):
 			// Set VMs in the PlanSpec
 			planSpec.VMs = vmList
 
+			if !dryRun && outputFormat != "" {
+				return fmt.Errorf("--output flag can only be used with --dry-run")
+			}
+			if dryRun && outputFormat != "" && outputFormat != "json" && outputFormat != "yaml" {
+				return fmt.Errorf("invalid output format for dry-run: %s. Valid formats are: json, yaml", outputFormat)
+			}
+			resolvedFormat := outputFormat
+			if dryRun && resolvedFormat == "" {
+				resolvedFormat = "yaml"
+			}
+
 			opts := plan.CreatePlanOptions{
 				Name:                      name,
 				Namespace:                 namespace,
@@ -498,6 +512,8 @@ Affinity Syntax (KARL):
 				OffloadStorageEndpoint: offloadStorageEndpoint,
 				OffloadCACert:          offloadCACert,
 				OffloadInsecureSkipTLS: offloadInsecureSkipTLS,
+				DryRun:                 dryRun,
+				OutputFormat:           resolvedFormat,
 			}
 
 			err := plan.Create(cmd.Context(), opts)
@@ -577,6 +593,8 @@ Affinity Syntax (KARL):
 	cmd.Flags().BoolVar(&planSpec.SkipZoneNodeSelector, "skip-zone-node-selector", false, "Skip adding zone-based node selector to migrated VMs (EC2 only)")
 	cmd.Flags().StringVar(&customizationScripts, "customization-scripts", "", "ConfigMap containing customization scripts for guest conversion. Supports 'namespace/name' or 'name'")
 	cmd.Flags().StringVar(&planSpec.VirtV2vImage, "virt-v2v-image", "", "Override global virt-v2v container image for this plan")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Output Plan CR(s) to stdout instead of creating them")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format for dry-run (json, yaml). Defaults to yaml when --dry-run is used")
 	cmd.Flags().StringVar(&enableNestedVirtualization, "enable-nested-virtualization", "auto", "Enable nested virtualization on target VMs (true/false/auto)")
 	cmd.Flags().BoolVar(&planSpec.XfsCompatibility, "xfs-compatibility", false, "Use XFS-compatible virt-v2v image for this plan")
 	cmd.Flags().BoolVar(&planSpec.RDMAsLun, "rdm-as-lun", false, "Map VMware RDM disks as LUN devices (SCSI passthrough) in the target VM (vSphere only)")

--- a/cmd/create/provider.go
+++ b/cmd/create/provider.go
@@ -41,6 +41,9 @@ func NewProviderCmd(kubeConfigFlags *genericclioptions.ConfigFlags) *cobra.Comma
 	// HyperV specific flags
 	var smbUrl, smbUser, smbPassword string
 
+	var dryRun bool
+	var outputFormat string
+
 	// Check if MTV_VDDK_INIT_IMAGE environment variable is set
 	if envVddkInitImage := os.Getenv("MTV_VDDK_INIT_IMAGE"); envVddkInitImage != "" {
 		vddkInitImage = envVddkInitImage
@@ -124,6 +127,17 @@ Credentials can be provided directly via flags or through an existing Kubernetes
 				cacert = string(fileContent)
 			}
 
+			if !dryRun && outputFormat != "" {
+				return fmt.Errorf("--output flag can only be used with --dry-run")
+			}
+			if dryRun && outputFormat != "" && outputFormat != "json" && outputFormat != "yaml" {
+				return fmt.Errorf("invalid output format for dry-run: %s. Valid formats are: json, yaml", outputFormat)
+			}
+			resolvedFormat := outputFormat
+			if dryRun && resolvedFormat == "" {
+				resolvedFormat = "yaml"
+			}
+
 			options := providerutil.ProviderOptions{
 				Name:                   name,
 				Namespace:              namespace,
@@ -152,6 +166,8 @@ Credentials can be provided directly via flags or through an existing Kubernetes
 				SMBUrl:                 smbUrl,
 				SMBUser:                smbUser,
 				SMBPassword:            smbPassword,
+				DryRun:                 dryRun,
+				OutputFormat:           resolvedFormat,
 			}
 
 			return provider.Create(kubeConfigFlags, providerType.GetValue(), options)
@@ -198,6 +214,9 @@ Credentials can be provided directly via flags or through an existing Kubernetes
 	cmd.Flags().StringVar(&smbUrl, "smb-url", "", "SMB share URL for HyperV (e.g., //server/share)")
 	cmd.Flags().StringVar(&smbUser, "smb-user", "", "SMB username (defaults to HyperV username)")
 	cmd.Flags().StringVar(&smbPassword, "smb-password", "", "SMB password (defaults to HyperV password)")
+
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Output Provider CR(s) to stdout instead of creating them")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format for dry-run (json, yaml). Defaults to yaml when --dry-run is used")
 
 	// Add completion for provider type flag
 	if err := cmd.RegisterFlagCompletionFunc("type", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/e2e/mcp/Makefile
+++ b/e2e/mcp/Makefile
@@ -124,6 +124,11 @@ test-mappings: install
 test-inventory: install
 	$(PYTEST) $(PYTEST_ARGS) inventory/
 
+## test-dryrun: Run only dry-run and show-cli tests
+.PHONY: test-dryrun
+test-dryrun: install
+	$(PYTEST) $(PYTEST_ARGS) dryrun/
+
 ## test-health: Run only MTV health check tests
 .PHONY: test-health
 test-health: install

--- a/e2e/mcp/dryrun/test_dry_run.py
+++ b/e2e/mcp/dryrun/test_dry_run.py
@@ -1,0 +1,141 @@
+"""Dry-run · dry_run -- verify --dry-run outputs resource YAML/JSON without creating."""
+
+import pytest
+
+from conftest import (
+    COLD_VMS,
+    NETWORK_PAIRS,
+    OCP_PROVIDER_NAME,
+    STORAGE_PAIRS,
+    TEST_NAMESPACE,
+    VSPHERE_PROVIDER_NAME,
+    call_tool,
+)
+
+DRY_RUN_PLAN_NAME = "dryrun-e2e-plan"
+DRY_RUN_HOOK_NAME = "dryrun-e2e-hook"
+
+
+@pytest.mark.order(14)
+async def test_dry_run_create_provider(mcp_session):
+    """dry-run create provider should output Provider YAML without creating it."""
+    result = await call_tool(mcp_session, "mtv_write", {
+        "command": "create provider",
+        "flags": {
+            "name": "dryrun-ocp-provider",
+            "type": "openshift",
+            "namespace": TEST_NAMESPACE,
+            "dry_run": True,
+        },
+    })
+    assert result.get("return_value") == 0, f"Unexpected result: {result}"
+
+    output = result.get("output", "")
+    assert "kind" in output.lower(), f"Expected 'kind' in output: {output[:200]}"
+    assert "Provider" in output, f"Expected 'Provider' in output: {output[:200]}"
+    print(f"\n  dry-run create provider output length: {len(output)} chars")
+
+
+@pytest.mark.order(14)
+async def test_dry_run_create_hook(mcp_session):
+    """dry-run create hook should output Hook YAML without creating it."""
+    result = await call_tool(mcp_session, "mtv_write", {
+        "command": "create hook",
+        "flags": {
+            "name": DRY_RUN_HOOK_NAME,
+            "namespace": TEST_NAMESPACE,
+            "dry_run": True,
+        },
+    })
+    assert result.get("return_value") == 0, f"Unexpected result: {result}"
+
+    output = result.get("output", "")
+    assert "Hook" in output, f"Expected 'Hook' in output: {output[:200]}"
+    assert DRY_RUN_HOOK_NAME in output, f"Expected hook name in output: {output[:200]}"
+    print(f"\n  dry-run create hook output length: {len(output)} chars")
+
+
+@pytest.mark.order(14)
+async def test_dry_run_create_plan(mcp_session):
+    """dry-run create plan should output Plan YAML without creating it."""
+    result = await call_tool(mcp_session, "mtv_write", {
+        "command": "create plan",
+        "flags": {
+            "name": DRY_RUN_PLAN_NAME,
+            "source": VSPHERE_PROVIDER_NAME,
+            "target": OCP_PROVIDER_NAME,
+            "vms": COLD_VMS,
+            "network-pairs": NETWORK_PAIRS,
+            "storage-pairs": STORAGE_PAIRS,
+            "namespace": TEST_NAMESPACE,
+            "dry_run": True,
+        },
+    })
+    assert result.get("return_value") == 0, f"Unexpected result: {result}"
+
+    output = result.get("output", "")
+    assert "Plan" in output, f"Expected 'Plan' in output: {output[:200]}"
+    assert "forklift.konveyor.io" in output, (
+        f"Expected API group in output: {output[:200]}"
+    )
+    print(f"\n  dry-run create plan output length: {len(output)} chars")
+
+
+@pytest.mark.order(14)
+async def test_dry_run_create_hook_json(mcp_session):
+    """dry-run create hook with --output json should return valid JSON.
+
+    Uses a single-resource command (hook) so the CLI stdout is one JSON
+    object.  UnmarshalJSONResponse parses it into the 'data' field.
+    """
+    result = await call_tool(mcp_session, "mtv_write", {
+        "command": "create hook",
+        "flags": {
+            "name": "dryrun-json-hook",
+            "namespace": TEST_NAMESPACE,
+            "dry_run": True,
+            "output": "json",
+        },
+    })
+    assert result.get("return_value") == 0, f"Unexpected result: {result}"
+
+    # Single-resource JSON is parsed into 'data' by UnmarshalJSONResponse
+    parsed = result.get("data")
+    assert parsed is not None, (
+        f"Expected 'data' with parsed JSON, got keys: {list(result.keys())}"
+    )
+    # Normalize: if UnmarshalJSONResponse returned a single-item list, unwrap it
+    if isinstance(parsed, list):
+        assert len(parsed) == 1, (
+            f"Expected single-element list, got {len(parsed)} items"
+        )
+        parsed = parsed[0]
+    assert isinstance(parsed, dict), f"Expected dict, got {type(parsed).__name__}"
+    assert parsed.get("kind") == "Hook", f"Expected kind=Hook, got {parsed.get('kind')}"
+    assert "forklift.konveyor.io" in parsed.get("apiVersion", ""), (
+        f"Expected forklift API version: {parsed.get('apiVersion')}"
+    )
+    print(f"\n  dry-run JSON hook: kind={parsed['kind']}, apiVersion={parsed['apiVersion']}")
+
+
+@pytest.mark.order(14)
+async def test_dry_run_no_resource_created(mcp_session):
+    """After dry-run create plan, the plan should NOT exist in the cluster."""
+    result = await call_tool(mcp_session, "mtv_read", {
+        "command": "get plan",
+        "flags": {"namespace": TEST_NAMESPACE, "output": "json"},
+    })
+
+    assert result.get("return_value") == 0, f"get plan call failed: {result}"
+
+    data = result.get("data", [])
+    plans = data if isinstance(data, list) else [data]
+    plan_names = [
+        p.get("name") or p.get("metadata", {}).get("name", "")
+        for p in plans
+    ]
+    assert DRY_RUN_PLAN_NAME not in plan_names, (
+        f"Plan '{DRY_RUN_PLAN_NAME}' should NOT exist after dry-run, "
+        f"but found in: {plan_names}"
+    )
+    print(f"\n  Confirmed: '{DRY_RUN_PLAN_NAME}' was not created in the cluster")

--- a/e2e/mcp/dryrun/test_show_cli.py
+++ b/e2e/mcp/dryrun/test_show_cli.py
@@ -1,0 +1,61 @@
+"""Dry-run · show_cli -- verify show_cli returns CLI commands without executing."""
+
+import pytest
+
+from conftest import (
+    TEST_NAMESPACE,
+    call_tool,
+)
+
+
+@pytest.mark.order(5)
+async def test_show_cli_read(mcp_session):
+    """show_cli on mtv_read should return the equivalent CLI command."""
+    result = await call_tool(mcp_session, "mtv_read", {
+        "command": "get plan",
+        "flags": {"namespace": TEST_NAMESPACE},
+        "show_cli": True,
+    })
+    assert result.get("return_value") == 0, f"Unexpected result: {result}"
+
+    output = result.get("output", "")
+    assert "kubectl-mtv" in output, f"Expected 'kubectl-mtv' in output: {output}"
+    assert "get" in output, f"Expected 'get' in output: {output}"
+    assert "plan" in output, f"Expected 'plan' in output: {output}"
+    print(f"\n  show_cli read output: {output}")
+
+
+@pytest.mark.order(5)
+async def test_show_cli_write(mcp_session):
+    """show_cli on mtv_write should return the equivalent CLI command."""
+    result = await call_tool(mcp_session, "mtv_write", {
+        "command": "create provider",
+        "flags": {
+            "name": "show-cli-test",
+            "type": "openshift",
+            "namespace": TEST_NAMESPACE,
+        },
+        "show_cli": True,
+    })
+    assert result.get("return_value") == 0, f"Unexpected result: {result}"
+
+    output = result.get("output", "")
+    assert "kubectl-mtv" in output, f"Expected 'kubectl-mtv' in output: {output}"
+    assert "create" in output, f"Expected 'create' in output: {output}"
+    assert "provider" in output, f"Expected 'provider' in output: {output}"
+    print(f"\n  show_cli write output: {output}")
+
+
+@pytest.mark.order(5)
+async def test_show_cli_not_executed(mcp_session):
+    """show_cli should not execute the command -- no data field in response."""
+    result = await call_tool(mcp_session, "mtv_read", {
+        "command": "get plan",
+        "flags": {"namespace": TEST_NAMESPACE},
+        "show_cli": True,
+    })
+    assert result.get("return_value") == 0
+    assert "data" not in result or result.get("data") is None, (
+        "show_cli should not return data (command not executed)"
+    )
+    print("\n  Confirmed: show_cli does not execute the command")

--- a/e2e/mcp/pyproject.toml
+++ b/e2e/mcp/pyproject.toml
@@ -22,6 +22,7 @@ asyncio_default_fixture_loop_scope = "session"
 asyncio_default_test_loop_scope = "session"
 testpaths = [
     "setup",
+    "dryrun",
     "providers",
     "hosts",
     "plans",

--- a/pkg/cmd/create/hook/hook.go
+++ b/pkg/cmd/create/hook/hook.go
@@ -15,16 +15,19 @@ import (
 
 	forkliftv1beta1 "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/yaacov/kubectl-mtv/pkg/util/client"
+	"github.com/yaacov/kubectl-mtv/pkg/util/output"
 )
 
 // CreateHookOptions encapsulates the parameters for creating migration hooks.
 // This includes the hook name, namespace, configuration flags, and the HookSpec
 // containing the hook's operational parameters.
 type CreateHookOptions struct {
-	Name        string
-	Namespace   string
-	ConfigFlags *genericclioptions.ConfigFlags
-	HookSpec    forkliftv1beta1.HookSpec
+	Name         string
+	Namespace    string
+	ConfigFlags  *genericclioptions.ConfigFlags
+	HookSpec     forkliftv1beta1.HookSpec
+	DryRun       bool
+	OutputFormat string
 }
 
 // Create creates a new migration hook resource.
@@ -39,7 +42,6 @@ func Create(opts CreateHookOptions) error {
 	// Process and encode the playbook if provided
 	processedSpec := opts.HookSpec
 	if opts.HookSpec.Playbook != "" {
-		// If the playbook is not already base64 encoded, encode it
 		if !isBase64Encoded(opts.HookSpec.Playbook) {
 			encoded := base64.StdEncoding.EncodeToString([]byte(opts.HookSpec.Playbook))
 			processedSpec.Playbook = encoded
@@ -47,14 +49,28 @@ func Create(opts CreateHookOptions) error {
 		}
 	}
 
+	// Build the typed Hook object
+	hookObj := &forkliftv1beta1.Hook{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      opts.Name,
+			Namespace: opts.Namespace,
+		},
+		Spec: processedSpec,
+	}
+	hookObj.Kind = "Hook"
+	hookObj.APIVersion = forkliftv1beta1.SchemeGroupVersion.String()
+
+	if opts.DryRun {
+		return output.OutputResource(hookObj, opts.OutputFormat)
+	}
+
 	// Create the hook resource
-	hookObj, err := createSingleHook(opts.ConfigFlags, opts.Namespace, opts.Name, processedSpec)
+	createdHook, err := createSingleHook(opts.ConfigFlags, opts.Namespace, hookObj)
 	if err != nil {
 		return fmt.Errorf("failed to create hook %s: %v", opts.Name, err)
 	}
 
-	// Provide user feedback
-	fmt.Printf("hook/%s created\n", hookObj.Name)
+	fmt.Printf("hook/%s created\n", createdHook.Name)
 	klog.V(2).Infof("Created hook '%s' in namespace '%s'", opts.Name, opts.Namespace)
 
 	return nil
@@ -90,22 +106,8 @@ func isBase64Encoded(s string) bool {
 	return err == nil && len(s)%4 == 0
 }
 
-// createSingleHook creates a single Hook resource in Kubernetes.
-// It constructs the Hook object with the provided specification and creates it using the dynamic client.
-func createSingleHook(configFlags *genericclioptions.ConfigFlags, namespace, name string, spec forkliftv1beta1.HookSpec) (*forkliftv1beta1.Hook, error) {
-	// Create Hook resource
-	hookObj := &forkliftv1beta1.Hook{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Spec: spec,
-	}
-
-	// Set the API version and kind
-	hookObj.Kind = "Hook"
-	hookObj.APIVersion = forkliftv1beta1.SchemeGroupVersion.String()
-
+// createSingleHook creates a single Hook resource in Kubernetes using the dynamic client.
+func createSingleHook(configFlags *genericclioptions.ConfigFlags, namespace string, hookObj *forkliftv1beta1.Hook) (*forkliftv1beta1.Hook, error) {
 	// Convert to unstructured for dynamic client
 	unstructuredHook, err := runtime.DefaultUnstructuredConverter.ToUnstructured(hookObj)
 	if err != nil {
@@ -127,7 +129,7 @@ func createSingleHook(configFlags *genericclioptions.ConfigFlags, namespace, nam
 
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
-			return nil, fmt.Errorf("hook '%s' already exists in namespace '%s'", name, namespace)
+			return nil, fmt.Errorf("hook '%s' already exists in namespace '%s'", hookObj.Name, namespace)
 		}
 		return nil, fmt.Errorf("failed to create hook: %v", err)
 	}

--- a/pkg/cmd/create/host/host.go
+++ b/pkg/cmd/create/host/host.go
@@ -17,6 +17,7 @@ import (
 	forkliftv1beta1 "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/yaacov/kubectl-mtv/pkg/cmd/get/inventory"
 	"github.com/yaacov/kubectl-mtv/pkg/util/client"
+	"github.com/yaacov/kubectl-mtv/pkg/util/output"
 )
 
 // CreateHostOptions encapsulates the parameters for creating migration hosts.
@@ -37,6 +38,8 @@ type CreateHostOptions struct {
 	HostInsecureSkipTLS      bool
 	CACert                   string
 	HostSpec                 forkliftv1beta1.HostSpec
+	DryRun                   bool
+	OutputFormat             string
 }
 
 // Create creates new migration hosts for vSphere providers.
@@ -46,7 +49,7 @@ type CreateHostOptions struct {
 func Create(ctx context.Context, opts CreateHostOptions) error {
 	// Get the provider object and validate it's a vSphere provider
 	// Only vSphere providers support host creation
-	_, err := validateAndGetProvider(ctx, opts.ConfigFlags, opts.Provider, opts.Namespace)
+	provider, err := validateAndGetProvider(ctx, opts.ConfigFlags, opts.Provider, opts.Namespace)
 	if err != nil {
 		return err
 	}
@@ -74,6 +77,10 @@ func Create(ctx context.Context, opts CreateHostOptions) error {
 		return fmt.Errorf("failed to check provider endpoint type: %v", err)
 	}
 
+	// In dry-run mode we collect all resources first and only emit output after
+	// every host has been successfully built and validated.
+	var dryRunResources []interface{}
+
 	if providerHasESXIEndpoint && opts.ExistingSecret == "" && opts.Username == "" {
 		// For ESXi endpoints, reuse the provider's existing secret for efficiency
 		secret = providerSecret
@@ -89,13 +96,24 @@ func Create(ctx context.Context, opts CreateHostOptions) error {
 		// Use first host ID for secret naming when creating multiple hosts
 		firstHostID := opts.HostIDs[0]
 		firstHostResourceName := firstHostID + "-" + generateHash(firstHostID)
-		createdSecret, err = createHostSecret(opts.ConfigFlags, opts.Namespace, firstHostResourceName, opts.Username, opts.Password, opts.HostInsecureSkipTLS, opts.CACert)
-		if err != nil {
-			return fmt.Errorf("failed to create host secret: %v", err)
-		}
-		secret = &corev1.ObjectReference{
-			Name:      createdSecret.Name,
-			Namespace: createdSecret.Namespace,
+		if opts.DryRun {
+			sec := buildHostSecretObject(opts.Namespace, firstHostResourceName, opts.Username, opts.Password, opts.HostInsecureSkipTLS, opts.CACert, true)
+			sec.Kind = "Secret"
+			sec.APIVersion = "v1"
+			dryRunResources = append(dryRunResources, sec)
+			secret = &corev1.ObjectReference{
+				Name:      sec.Name,
+				Namespace: sec.Namespace,
+			}
+		} else {
+			createdSecret, err = createHostSecret(ctx, opts.ConfigFlags, opts.Namespace, firstHostResourceName, opts.Username, opts.Password, opts.HostInsecureSkipTLS, opts.CACert)
+			if err != nil {
+				return fmt.Errorf("failed to create host secret: %v", err)
+			}
+			secret = &corev1.ObjectReference{
+				Name:      createdSecret.Name,
+				Namespace: createdSecret.Namespace,
+			}
 		}
 	}
 
@@ -107,8 +125,17 @@ func Create(ctx context.Context, opts CreateHostOptions) error {
 			return fmt.Errorf("failed to resolve IP address for host %s: %v", hostID, err)
 		}
 
+		if opts.DryRun {
+			hostObj, err := buildSingleHost(ctx, opts.ConfigFlags, opts.Namespace, hostID, provider, hostIP, secret, availableHosts)
+			if err != nil {
+				return fmt.Errorf("failed to build host %s: %v", hostID, err)
+			}
+			dryRunResources = append(dryRunResources, hostObj)
+			continue
+		}
+
 		// Create the host resource with provider ownership
-		hostObj, err := createSingleHost(ctx, opts.ConfigFlags, opts.Namespace, hostID, opts.Provider, hostIP, secret, availableHosts)
+		hostObj, err := createSingleHost(ctx, opts.ConfigFlags, opts.Namespace, hostID, provider, hostIP, secret, availableHosts)
 		if err != nil {
 			return fmt.Errorf("failed to create host %s: %v", hostID, err)
 		}
@@ -116,7 +143,7 @@ func Create(ctx context.Context, opts CreateHostOptions) error {
 		// If we created a new secret, add this host as an owner for proper garbage collection
 		// This ensures the secret is deleted only when all hosts using it are deleted
 		if createdSecret != nil {
-			err = addHostAsSecretOwner(opts.ConfigFlags, opts.Namespace, createdSecret.Name, hostObj)
+			err = addHostAsSecretOwner(ctx, opts.ConfigFlags, opts.Namespace, createdSecret.Name, hostObj)
 			if err != nil {
 				return fmt.Errorf("failed to add host %s as owner of secret %s: %v", hostID, createdSecret.Name, err)
 			}
@@ -126,6 +153,16 @@ func Create(ctx context.Context, opts CreateHostOptions) error {
 		fmt.Printf("host/%s created\n", hostObj.Name)
 
 		klog.V(2).Infof("Created host '%s' in namespace '%s'", hostID, opts.Namespace)
+	}
+
+	// Emit all dry-run resources only after all hosts have been built successfully
+	if opts.DryRun {
+		for _, res := range dryRunResources {
+			if err := output.OutputResource(res, opts.OutputFormat); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 
 	if createdSecret != nil {
@@ -241,16 +278,9 @@ func resolveHostIPAddress(directIP, networkAdapterName, hostID string, available
 	return "", fmt.Errorf("network adapter '%s' not found for host '%s' or no IP address available", networkAdapterName, hostID)
 }
 
-// createSingleHost creates a single Host resource with proper ownership by the provider.
-// It extracts the host ID from inventory, sets up owner references, and creates the Kubernetes resource.
-// Returns the created host object for use in establishing secret ownership.
-func createSingleHost(ctx context.Context, configFlags *genericclioptions.ConfigFlags, namespace, hostID, providerName, ipAddress string, secret *corev1.ObjectReference, availableHosts []map[string]interface{}) (*forkliftv1beta1.Host, error) {
-	provider, err := inventory.GetProviderByName(ctx, configFlags, providerName, namespace)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get provider for ownership: %v", err)
-	}
-
-	// Create Host resource with provider as controlling owner for lifecycle management
+// buildSingleHost constructs a Host resource with provider ownership and secret reference without persisting it.
+// The provider parameter is the already-validated provider object fetched once by the caller.
+func buildSingleHost(ctx context.Context, configFlags *genericclioptions.ConfigFlags, namespace, hostID string, provider *unstructured.Unstructured, ipAddress string, secret *corev1.ObjectReference, availableHosts []map[string]interface{}) (*forkliftv1beta1.Host, error) {
 	hostResourceName := hostID + "-" + generateHash(hostID)
 	hostObj := &forkliftv1beta1.Host{
 		ObjectMeta: metav1.ObjectMeta{
@@ -270,7 +300,7 @@ func createSingleHost(ctx context.Context, configFlags *genericclioptions.Config
 			Provider: corev1.ObjectReference{
 				Kind:       "Provider",
 				APIVersion: forkliftv1beta1.SchemeGroupVersion.String(),
-				Name:       providerName,
+				Name:       provider.GetName(),
 				Namespace:  namespace,
 			},
 			IpAddress: ipAddress,
@@ -283,6 +313,18 @@ func createSingleHost(ctx context.Context, configFlags *genericclioptions.Config
 	hostObj.Kind = "Host"
 	hostObj.APIVersion = forkliftv1beta1.SchemeGroupVersion.String()
 
+	return hostObj, nil
+}
+
+// createSingleHost creates a single Host resource with proper ownership by the provider.
+// It sets up owner references and creates the Kubernetes resource.
+// Returns the created host object for use in establishing secret ownership.
+func createSingleHost(ctx context.Context, configFlags *genericclioptions.ConfigFlags, namespace, hostID string, provider *unstructured.Unstructured, ipAddress string, secret *corev1.ObjectReference, availableHosts []map[string]interface{}) (*forkliftv1beta1.Host, error) {
+	hostObj, err := buildSingleHost(ctx, configFlags, namespace, hostID, provider, ipAddress, secret, availableHosts)
+	if err != nil {
+		return nil, err
+	}
+
 	unstructuredHost, err := runtime.DefaultUnstructuredConverter.ToUnstructured(hostObj)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert host to unstructured: %v", err)
@@ -294,7 +336,7 @@ func createSingleHost(ctx context.Context, configFlags *genericclioptions.Config
 	}
 
 	createdHostUnstructured, err := dynamicClient.Resource(client.HostsGVR).Namespace(namespace).Create(
-		context.Background(),
+		ctx,
 		&unstructured.Unstructured{Object: unstructuredHost},
 		metav1.CreateOptions{},
 	)
@@ -333,15 +375,9 @@ func generateHash(input string) string {
 	return fmt.Sprintf("%x", hash[:2]) // 2 bytes = 4 hex characters
 }
 
-// createHostSecret creates a Kubernetes Secret containing host authentication credentials.
-// The secret is labeled to associate it with the host resource and includes optional
-// TLS configuration for secure or insecure connections.
-func createHostSecret(configFlags *genericclioptions.ConfigFlags, namespace, hostResourceName, username, password string, hostInsecureSkipTLS bool, cacert string) (*corev1.Secret, error) {
-	k8sClient, err := client.GetKubernetesClientset(configFlags)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create kubernetes client: %v", err)
-	}
-
+// buildHostSecretObject builds a Kubernetes Secret for host credentials without persisting it.
+// When dryRun is true, the secret uses a deterministic Name suitable for dry-run output; otherwise GenerateName is used.
+func buildHostSecretObject(namespace, hostResourceName, username, password string, hostInsecureSkipTLS bool, cacert string, dryRun bool) *corev1.Secret {
 	secretData := map[string][]byte{
 		"user":     []byte(username),
 		"password": []byte(password),
@@ -354,34 +390,49 @@ func createHostSecret(configFlags *genericclioptions.ConfigFlags, namespace, hos
 		secretData["cacert"] = []byte(cacert)
 	}
 
-	secretName := fmt.Sprintf("%s-host-", hostResourceName)
-
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: secretName,
-			Namespace:    namespace,
-			Labels: map[string]string{
-				"createdForResource":     hostResourceName,
-				"createdForResourceType": "hosts",
-			},
+	meta := metav1.ObjectMeta{
+		Namespace: namespace,
+		Labels: map[string]string{
+			"createdForResource":     hostResourceName,
+			"createdForResourceType": "hosts",
 		},
-		Data: secretData,
-		Type: corev1.SecretTypeOpaque,
+	}
+	if dryRun {
+		meta.Name = fmt.Sprintf("%s-host-dryrun", hostResourceName)
+	} else {
+		meta.GenerateName = fmt.Sprintf("%s-host-", hostResourceName)
 	}
 
-	return k8sClient.CoreV1().Secrets(namespace).Create(context.Background(), secret, metav1.CreateOptions{})
+	return &corev1.Secret{
+		ObjectMeta: meta,
+		Data:       secretData,
+		Type:       corev1.SecretTypeOpaque,
+	}
+}
+
+// createHostSecret creates a Kubernetes Secret containing host authentication credentials.
+// The secret is labeled to associate it with the host resource and includes optional
+// TLS configuration for secure or insecure connections.
+func createHostSecret(ctx context.Context, configFlags *genericclioptions.ConfigFlags, namespace, hostResourceName, username, password string, hostInsecureSkipTLS bool, cacert string) (*corev1.Secret, error) {
+	k8sClient, err := client.GetKubernetesClientset(configFlags)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client: %v", err)
+	}
+
+	secret := buildHostSecretObject(namespace, hostResourceName, username, password, hostInsecureSkipTLS, cacert, false)
+	return k8sClient.CoreV1().Secrets(namespace).Create(ctx, secret, metav1.CreateOptions{})
 }
 
 // addHostAsSecretOwner adds a host as an owner reference to a secret, enabling proper
 // garbage collection. When multiple hosts share a secret, each becomes an owner, and
 // the secret is only deleted when all owning hosts are removed.
-func addHostAsSecretOwner(configFlags *genericclioptions.ConfigFlags, namespace, secretName string, host *forkliftv1beta1.Host) error {
+func addHostAsSecretOwner(ctx context.Context, configFlags *genericclioptions.ConfigFlags, namespace, secretName string, host *forkliftv1beta1.Host) error {
 	k8sClient, err := client.GetKubernetesClientset(configFlags)
 	if err != nil {
 		return fmt.Errorf("failed to create kubernetes client: %v", err)
 	}
 
-	secret, err := k8sClient.CoreV1().Secrets(namespace).Get(context.Background(), secretName, metav1.GetOptions{})
+	secret, err := k8sClient.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to get secret %s: %v", secretName, err)
 	}
@@ -404,7 +455,7 @@ func addHostAsSecretOwner(configFlags *genericclioptions.ConfigFlags, namespace,
 
 	secret.OwnerReferences = append(secret.OwnerReferences, hostOwnerRef)
 
-	_, err = k8sClient.CoreV1().Secrets(namespace).Update(context.Background(), secret, metav1.UpdateOptions{})
+	_, err = k8sClient.CoreV1().Secrets(namespace).Update(ctx, secret, metav1.UpdateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to update secret %s with host owner reference: %v", secretName, err)
 	}

--- a/pkg/cmd/create/mapping/mapping.go
+++ b/pkg/cmd/create/mapping/mapping.go
@@ -22,6 +22,8 @@ type StorageCreateOptions struct {
 	DefaultOffloadPlugin     string
 	DefaultOffloadSecret     string
 	DefaultOffloadVendor     string
+	DryRun                   bool
+	OutputFormat             string
 	// Offload secret creation fields
 	OffloadVSphereUsername string
 	OffloadVSpherePassword string
@@ -50,12 +52,12 @@ type StorageParseOptions struct {
 
 // CreateNetwork creates a new network mapping
 func CreateNetwork(configFlags *genericclioptions.ConfigFlags, name, namespace, sourceProvider, targetProvider, networkPairs, inventoryURL string) error {
-	return CreateNetworkWithInsecure(configFlags, name, namespace, sourceProvider, targetProvider, networkPairs, inventoryURL, false)
+	return CreateNetworkWithInsecure(configFlags, name, namespace, sourceProvider, targetProvider, networkPairs, inventoryURL, false, false, "")
 }
 
 // CreateNetworkWithInsecure creates a new network mapping with optional insecure TLS skip verification
-func CreateNetworkWithInsecure(configFlags *genericclioptions.ConfigFlags, name, namespace, sourceProvider, targetProvider, networkPairs, inventoryURL string, insecureSkipTLS bool) error {
-	return createNetworkMappingWithInsecure(configFlags, name, namespace, sourceProvider, targetProvider, networkPairs, inventoryURL, insecureSkipTLS)
+func CreateNetworkWithInsecure(configFlags *genericclioptions.ConfigFlags, name, namespace, sourceProvider, targetProvider, networkPairs, inventoryURL string, insecureSkipTLS bool, dryRun bool, outputFormat string) error {
+	return createNetworkMappingWithInsecure(configFlags, name, namespace, sourceProvider, targetProvider, networkPairs, inventoryURL, insecureSkipTLS, dryRun, outputFormat)
 }
 
 // CreateStorageWithOptions creates a new storage mapping with additional options for VolumeMode, AccessMode, and OffloadPlugin

--- a/pkg/cmd/create/mapping/network.go
+++ b/pkg/cmd/create/mapping/network.go
@@ -14,6 +14,7 @@ import (
 	forkliftv1beta1 "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/provider"
 	"github.com/yaacov/kubectl-mtv/pkg/util/client"
+	"github.com/yaacov/kubectl-mtv/pkg/util/output"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -176,18 +177,14 @@ func parseNetworkPairsWithInsecure(ctx context.Context, pairStr, defaultNamespac
 }
 
 // createNetworkMappingWithInsecure creates a new network mapping with optional insecure TLS skip verification
-func createNetworkMappingWithInsecure(configFlags *genericclioptions.ConfigFlags, name, namespace, sourceProvider, targetProvider, networkPairs, inventoryURL string, insecureSkipTLS bool) error {
-	dynamicClient, err := client.GetDynamicClient(configFlags)
-	if err != nil {
-		return fmt.Errorf("failed to get client: %v", err)
-	}
-
+func createNetworkMappingWithInsecure(configFlags *genericclioptions.ConfigFlags, name, namespace, sourceProvider, targetProvider, networkPairs, inventoryURL string, insecureSkipTLS bool, dryRun bool, outputFormat string) error {
 	// Parse provider references to extract names and namespaces
 	sourceProviderName, sourceProviderNamespace := parseProviderReference(sourceProvider, namespace)
 	targetProviderName, targetProviderNamespace := parseProviderReference(targetProvider, namespace)
 
 	// Parse network pairs if provided
 	var mappingPairs []forkliftv1beta1.NetworkPair
+	var err error
 	if networkPairs != "" {
 		mappingPairs, err = parseNetworkPairsWithInsecure(context.TODO(), networkPairs, namespace, configFlags, sourceProvider, inventoryURL, insecureSkipTLS)
 		if err != nil {
@@ -214,6 +211,17 @@ func createNetworkMappingWithInsecure(configFlags *genericclioptions.ConfigFlags
 			},
 			Map: mappingPairs,
 		},
+	}
+	networkMap.Kind = "NetworkMap"
+	networkMap.APIVersion = forkliftv1beta1.SchemeGroupVersion.String()
+
+	if dryRun {
+		return output.OutputResource(networkMap, outputFormat)
+	}
+
+	dynamicClient, err := client.GetDynamicClient(configFlags)
+	if err != nil {
+		return fmt.Errorf("failed to get client: %v", err)
 	}
 
 	// Convert to unstructured

--- a/pkg/cmd/create/mapping/offload_secrets.go
+++ b/pkg/cmd/create/mapping/offload_secrets.go
@@ -13,14 +13,9 @@ import (
 	"github.com/yaacov/kubectl-mtv/pkg/util/client"
 )
 
-// createOffloadSecret creates a secret for offload plugin authentication
-func createOffloadSecret(configFlags *genericclioptions.ConfigFlags, namespace, baseName string, opts StorageCreateOptions) (*corev1.Secret, error) {
-	// Get the Kubernetes client using configFlags
-	k8sClient, err := client.GetKubernetesClientset(configFlags)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create kubernetes client: %v", err)
-	}
-
+// buildOffloadSecret constructs the offload Secret object without persisting it.
+// For dry-run a deterministic Name is used; for live create GenerateName is used.
+func buildOffloadSecret(namespace, baseName string, opts StorageCreateOptions, dryRun bool) (*corev1.Secret, error) {
 	// Process CA certificate file if specified with @filename
 	cacert := opts.OffloadCACert
 	if strings.HasPrefix(cacert, "@") {
@@ -32,10 +27,8 @@ func createOffloadSecret(configFlags *genericclioptions.ConfigFlags, namespace, 
 		cacert = string(fileContent)
 	}
 
-	// Create secret data without base64 encoding (the API handles this automatically)
 	secretData := map[string][]byte{}
 
-	// Add vSphere credentials (required)
 	if opts.OffloadVSphereUsername != "" {
 		secretData["user"] = []byte(opts.OffloadVSphereUsername)
 	}
@@ -45,8 +38,6 @@ func createOffloadSecret(configFlags *genericclioptions.ConfigFlags, namespace, 
 	if opts.OffloadVSphereURL != "" {
 		secretData["url"] = []byte(opts.OffloadVSphereURL)
 	}
-
-	// Add storage array credentials (required)
 	if opts.OffloadStorageUsername != "" {
 		secretData["storageUser"] = []byte(opts.OffloadStorageUsername)
 	}
@@ -56,8 +47,6 @@ func createOffloadSecret(configFlags *genericclioptions.ConfigFlags, namespace, 
 	if opts.OffloadStorageEndpoint != "" {
 		secretData["storageEndpoint"] = []byte(opts.OffloadStorageEndpoint)
 	}
-
-	// Add optional TLS fields
 	if opts.OffloadInsecureSkipTLS {
 		secretData["insecureSkipVerify"] = []byte("true")
 	}
@@ -65,26 +54,41 @@ func createOffloadSecret(configFlags *genericclioptions.ConfigFlags, namespace, 
 		secretData["cacert"] = []byte(cacert)
 	}
 
-	// Validate that we have the minimum required fields
 	if len(secretData) == 0 {
 		return nil, fmt.Errorf("no offload secret fields provided")
 	}
 
-	// Generate a name prefix for the secret
-	secretName := fmt.Sprintf("%s-offload-", baseName)
-
-	// Create the secret object directly as a typed Secret
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: secretName,
-			Namespace:    namespace,
-			Labels: map[string]string{
-				"createdForResourceType": "offload",
-				"createdForMapping":      baseName,
-			},
+	meta := metav1.ObjectMeta{
+		Namespace: namespace,
+		Labels: map[string]string{
+			"createdForResourceType": "offload",
+			"createdForMapping":      baseName,
 		},
-		Data: secretData,
-		Type: corev1.SecretTypeOpaque,
+	}
+	if dryRun {
+		meta.Name = fmt.Sprintf("%s-offload", baseName)
+	} else {
+		meta.GenerateName = fmt.Sprintf("%s-offload-", baseName)
+	}
+
+	return &corev1.Secret{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+		ObjectMeta: meta,
+		Data:       secretData,
+		Type:       corev1.SecretTypeOpaque,
+	}, nil
+}
+
+// createOffloadSecret creates a secret for offload plugin authentication
+func createOffloadSecret(configFlags *genericclioptions.ConfigFlags, namespace, baseName string, opts StorageCreateOptions) (*corev1.Secret, error) {
+	k8sClient, err := client.GetKubernetesClientset(configFlags)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client: %v", err)
+	}
+
+	secret, err := buildOffloadSecret(namespace, baseName, opts, false)
+	if err != nil {
+		return nil, err
 	}
 
 	return k8sClient.CoreV1().Secrets(namespace).Create(context.Background(), secret, metav1.CreateOptions{})

--- a/pkg/cmd/create/mapping/storage.go
+++ b/pkg/cmd/create/mapping/storage.go
@@ -15,6 +15,7 @@ import (
 	forkliftv1beta1 "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/provider"
 	"github.com/yaacov/kubectl-mtv/pkg/util/client"
+	"github.com/yaacov/kubectl-mtv/pkg/util/output"
 )
 
 // validateVolumeMode validates volume mode values
@@ -232,20 +233,16 @@ func parseStoragePairsInternal(pairStr, defaultNamespace string, configFlags *ge
 }
 
 // createStorageMappingWithOptions creates a new storage mapping with additional options for VolumeMode, AccessMode, and OffloadPlugin
-func createStorageMappingWithOptions(ctx context.Context, configFlags *genericclioptions.ConfigFlags, name, namespace, sourceProvider, targetProvider, storagePairs, inventoryURL string, defaultVolumeMode, defaultAccessMode, defaultOffloadPlugin, defaultOffloadSecret, defaultOffloadVendor string, insecureSkipTLS bool) error {
-	dynamicClient, err := client.GetDynamicClient(configFlags)
-	if err != nil {
-		return fmt.Errorf("failed to get client: %v", err)
-	}
-
+func createStorageMappingWithOptions(ctx context.Context, opts StorageCreateOptions) error {
 	// Parse provider references to extract names and namespaces
-	sourceProviderName, sourceProviderNamespace := parseProviderReference(sourceProvider, namespace)
-	targetProviderName, targetProviderNamespace := parseProviderReference(targetProvider, namespace)
+	sourceProviderName, sourceProviderNamespace := parseProviderReference(opts.SourceProvider, opts.Namespace)
+	targetProviderName, targetProviderNamespace := parseProviderReference(opts.TargetProvider, opts.Namespace)
 
 	// Parse storage pairs if provided
 	var mappingPairs []forkliftv1beta1.StoragePair
-	if storagePairs != "" {
-		mappingPairs, err = parseStoragePairsWithOptions(ctx, storagePairs, namespace, configFlags, sourceProvider, inventoryURL, defaultVolumeMode, defaultAccessMode, defaultOffloadPlugin, defaultOffloadSecret, defaultOffloadVendor, insecureSkipTLS)
+	var err error
+	if opts.StoragePairs != "" {
+		mappingPairs, err = parseStoragePairsWithOptions(ctx, opts.StoragePairs, opts.Namespace, opts.ConfigFlags, opts.SourceProvider, opts.InventoryURL, opts.DefaultVolumeMode, opts.DefaultAccessMode, opts.DefaultOffloadPlugin, opts.DefaultOffloadSecret, opts.DefaultOffloadVendor, opts.InventoryInsecureSkipTLS)
 		if err != nil {
 			return fmt.Errorf("failed to parse storage pairs: %v", err)
 		}
@@ -254,8 +251,8 @@ func createStorageMappingWithOptions(ctx context.Context, configFlags *genericcl
 	// Create a typed StorageMap
 	storageMap := &forkliftv1beta1.StorageMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name:      opts.Name,
+			Namespace: opts.Namespace,
 		},
 		Spec: forkliftv1beta1.StorageMapSpec{
 			Provider: provider.Pair{
@@ -271,6 +268,17 @@ func createStorageMappingWithOptions(ctx context.Context, configFlags *genericcl
 			Map: mappingPairs,
 		},
 	}
+	storageMap.Kind = "StorageMap"
+	storageMap.APIVersion = forkliftv1beta1.SchemeGroupVersion.String()
+
+	if opts.DryRun {
+		return output.OutputResource(storageMap, opts.OutputFormat)
+	}
+
+	dynamicClient, err := client.GetDynamicClient(opts.ConfigFlags)
+	if err != nil {
+		return fmt.Errorf("failed to get client: %v", err)
+	}
 
 	// Convert to unstructured
 	unstructuredObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(storageMap)
@@ -285,12 +293,12 @@ func createStorageMappingWithOptions(ctx context.Context, configFlags *genericcl
 		Kind:    "StorageMap",
 	})
 
-	_, err = dynamicClient.Resource(client.StorageMapGVR).Namespace(namespace).Create(context.TODO(), mapping, metav1.CreateOptions{})
+	_, err = dynamicClient.Resource(client.StorageMapGVR).Namespace(opts.Namespace).Create(ctx, mapping, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to create storage mapping: %v", err)
 	}
 
-	fmt.Printf("storagemap/%s created\n", name)
+	fmt.Printf("storagemap/%s created\n", opts.Name)
 	return nil
 }
 
@@ -304,30 +312,37 @@ func createStorageMappingWithOptionsAndSecret(ctx context.Context, opts StorageC
 		return err
 	}
 
-	// Determine if we need to create an offload secret
-	if needsOffloadSecret(opts) {
-		fmt.Printf("Creating offload secret for storage mapping '%s'\n", opts.Name)
+	effectiveOpts := opts
 
-		createdOffloadSecret, err = createOffloadSecret(opts.ConfigFlags, opts.Namespace, opts.Name, opts)
+	// Dry-run: build and emit the offload Secret so users see all resources that would be created
+	if effectiveOpts.DryRun && needsOffloadSecret(effectiveOpts) {
+		sec, err := buildOffloadSecret(effectiveOpts.Namespace, effectiveOpts.Name, effectiveOpts, true)
+		if err != nil {
+			return fmt.Errorf("failed to build offload secret for dry-run: %v", err)
+		}
+		if err := output.OutputResource(sec, effectiveOpts.OutputFormat); err != nil {
+			return err
+		}
+		effectiveOpts.DefaultOffloadSecret = sec.Name
+	} else if !effectiveOpts.DryRun && needsOffloadSecret(effectiveOpts) {
+		fmt.Printf("Creating offload secret for storage mapping '%s'\n", effectiveOpts.Name)
+
+		createdOffloadSecret, err = createOffloadSecret(effectiveOpts.ConfigFlags, effectiveOpts.Namespace, effectiveOpts.Name, effectiveOpts)
 		if err != nil {
 			return fmt.Errorf("failed to create offload secret: %v", err)
 		}
 
 		// Use the created secret name as the default offload secret
-		opts.DefaultOffloadSecret = createdOffloadSecret.Name
+		effectiveOpts.DefaultOffloadSecret = createdOffloadSecret.Name
 		fmt.Printf("Created offload secret '%s' for storage mapping authentication\n", createdOffloadSecret.Name)
 	}
 
-	// Call the original function with the updated options
-	err = createStorageMappingWithOptions(ctx, opts.ConfigFlags, opts.Name, opts.Namespace,
-		opts.SourceProvider, opts.TargetProvider, opts.StoragePairs, opts.InventoryURL,
-		opts.DefaultVolumeMode, opts.DefaultAccessMode, opts.DefaultOffloadPlugin,
-		opts.DefaultOffloadSecret, opts.DefaultOffloadVendor, opts.InventoryInsecureSkipTLS)
+	err = createStorageMappingWithOptions(ctx, effectiveOpts)
 
 	if err != nil {
 		// Clean up the created secret if mapping creation fails
 		if createdOffloadSecret != nil {
-			if delErr := cleanupOffloadSecret(opts.ConfigFlags, opts.Namespace, createdOffloadSecret.Name); delErr != nil {
+			if delErr := cleanupOffloadSecret(effectiveOpts.ConfigFlags, effectiveOpts.Namespace, createdOffloadSecret.Name); delErr != nil {
 				fmt.Printf("Warning: failed to clean up offload secret '%s': %v\n", createdOffloadSecret.Name, delErr)
 			}
 		}

--- a/pkg/cmd/create/plan/network/factory.go
+++ b/pkg/cmd/create/plan/network/factory.go
@@ -33,6 +33,7 @@ import (
 	vsphereMapper "github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/network/mapper/vsphere"
 	"github.com/yaacov/kubectl-mtv/pkg/cmd/get/inventory"
 	"github.com/yaacov/kubectl-mtv/pkg/util/client"
+	"github.com/yaacov/kubectl-mtv/pkg/util/output"
 )
 
 // NetworkMapperInterface defines the interface for network mapping operations
@@ -61,6 +62,8 @@ type NetworkMapperOptions struct {
 	InventoryInsecureSkipTLS bool
 	PlanVMNames              []string
 	DefaultTargetNetwork     string
+	DryRun                   bool
+	OutputFormat             string
 }
 
 // GetSourceNetworkFetcher returns the appropriate source network fetcher based on provider type
@@ -273,12 +276,23 @@ func CreateNetworkMap(ctx context.Context, opts NetworkMapperOptions) (string, e
 		return "", fmt.Errorf("failed to create network pairs: %v", err)
 	}
 
+	if opts.DryRun {
+		networkMap, networkMapName, err := buildNetworkMapObject(opts, networkPairs)
+		if err != nil {
+			return "", err
+		}
+		if err := output.OutputResource(networkMap, opts.OutputFormat); err != nil {
+			return "", err
+		}
+		return networkMapName, nil
+	}
+
 	// Create the network map using the existing infrastructure
 	return createNetworkMap(opts, networkPairs)
 }
 
-// createNetworkMap helper function to create the actual network map resource
-func createNetworkMap(opts NetworkMapperOptions, networkPairs []forkliftv1beta1.NetworkPair) (string, error) {
+// buildNetworkMapObject builds a typed NetworkMap (no API call).
+func buildNetworkMapObject(opts NetworkMapperOptions, networkPairs []forkliftv1beta1.NetworkPair) (*forkliftv1beta1.NetworkMap, string, error) {
 	// If no network pairs, create a dummy pair
 	if len(networkPairs) == 0 {
 		klog.V(4).Infof("DEBUG: No network pairs found, creating dummy pair")
@@ -294,10 +308,8 @@ func createNetworkMap(opts NetworkMapperOptions, networkPairs []forkliftv1beta1.
 		}
 	}
 
-	// Create the network map name
 	networkMapName := opts.Name + "-network-map"
 
-	// Create NetworkMap object
 	networkMap := &forkliftv1beta1.NetworkMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      networkMapName,
@@ -323,6 +335,15 @@ func createNetworkMap(opts NetworkMapperOptions, networkPairs []forkliftv1beta1.
 	}
 	networkMap.Kind = "NetworkMap"
 	networkMap.APIVersion = forkliftv1beta1.SchemeGroupVersion.String()
+	return networkMap, networkMapName, nil
+}
+
+// createNetworkMap helper function to create the actual network map resource
+func createNetworkMap(opts NetworkMapperOptions, networkPairs []forkliftv1beta1.NetworkPair) (string, error) {
+	networkMap, networkMapName, err := buildNetworkMapObject(opts, networkPairs)
+	if err != nil {
+		return "", err
+	}
 
 	// Convert to Unstructured
 	unstructuredMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(networkMap)

--- a/pkg/cmd/create/plan/plan.go
+++ b/pkg/cmd/create/plan/plan.go
@@ -24,6 +24,7 @@ import (
 	"github.com/yaacov/kubectl-mtv/pkg/cmd/create/provider/defaultprovider"
 	"github.com/yaacov/kubectl-mtv/pkg/cmd/get/inventory"
 	"github.com/yaacov/kubectl-mtv/pkg/util/client"
+	"github.com/yaacov/kubectl-mtv/pkg/util/output"
 )
 
 // CreatePlanOptions encapsulates the parameters for the Create function.
@@ -61,6 +62,9 @@ type CreatePlanOptions struct {
 	OffloadStorageEndpoint string
 	OffloadCACert          string
 	OffloadInsecureSkipTLS bool
+
+	DryRun       bool
+	OutputFormat string
 }
 
 // parseProviderName parses a provider name that might contain namespace/name pattern
@@ -89,12 +93,14 @@ func Create(ctx context.Context, opts CreatePlanOptions) error {
 	opts.SourceProvider = sourceProviderName
 	opts.SourceProviderNamespace = sourceProviderNamespace
 
-	// If the plan already exists, return an error
-	_, err = c.Resource(client.PlansGVR).Namespace(opts.Namespace).Get(context.TODO(), opts.Name, metav1.GetOptions{})
-	if err == nil {
-		return fmt.Errorf("plan '%s' already exists in namespace '%s'", opts.Name, opts.Namespace)
-	} else if !errors.IsNotFound(err) {
-		return fmt.Errorf("failed to check if plan exists: %v", err)
+	// If the plan already exists, return an error (skip check for dry-run)
+	if !opts.DryRun {
+		_, err = c.Resource(client.PlansGVR).Namespace(opts.Namespace).Get(ctx, opts.Name, metav1.GetOptions{})
+		if err == nil {
+			return fmt.Errorf("plan '%s' already exists in namespace '%s'", opts.Name, opts.Namespace)
+		} else if !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to check if plan exists: %v", err)
+		}
 	}
 
 	// If target provider is not provided, find the first OpenShift provider
@@ -149,13 +155,15 @@ func Create(ctx context.Context, opts CreatePlanOptions) error {
 			if opts.TargetProviderNamespace != opts.Namespace {
 				targetProviderRef = fmt.Sprintf("%s/%s", opts.TargetProviderNamespace, opts.TargetProvider)
 			}
-			err := mapping.CreateNetwork(opts.ConfigFlags, networkMapName, opts.Namespace, sourceProviderRef, targetProviderRef, opts.NetworkPairs, opts.InventoryURL)
+			err := mapping.CreateNetworkWithInsecure(opts.ConfigFlags, networkMapName, opts.Namespace, sourceProviderRef, targetProviderRef, opts.NetworkPairs, opts.InventoryURL, opts.InventoryInsecureSkipTLS, opts.DryRun, opts.OutputFormat)
 			if err != nil {
 				return fmt.Errorf("failed to create network map from pairs: %v", err)
 			}
 			opts.NetworkMapping = networkMapName
-			createdNetworkMap = true
-			fmt.Printf("Created network mapping '%s' from provided pairs\n", networkMapName)
+			if !opts.DryRun {
+				createdNetworkMap = true
+				fmt.Printf("Created network mapping '%s' from provided pairs\n", networkMapName)
+			}
 		} else {
 			// Create default network mapping using existing logic
 			networkMapName, err := network.CreateNetworkMap(ctx, network.NetworkMapperOptions{
@@ -171,12 +179,16 @@ func Create(ctx context.Context, opts CreatePlanOptions) error {
 				InventoryInsecureSkipTLS: opts.InventoryInsecureSkipTLS,
 				PlanVMNames:              planVMNames,
 				DefaultTargetNetwork:     opts.DefaultTargetNetwork,
+				DryRun:                   opts.DryRun,
+				OutputFormat:             opts.OutputFormat,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to create default network map: %v", err)
 			}
 			opts.NetworkMapping = networkMapName
-			createdNetworkMap = true
+			if !opts.DryRun {
+				createdNetworkMap = true
+			}
 		}
 	}
 
@@ -209,6 +221,8 @@ func Create(ctx context.Context, opts CreatePlanOptions) error {
 				DefaultOffloadPlugin:     opts.DefaultOffloadPlugin,
 				DefaultOffloadSecret:     opts.DefaultOffloadSecret,
 				DefaultOffloadVendor:     opts.DefaultOffloadVendor,
+				DryRun:                   opts.DryRun,
+				OutputFormat:             opts.OutputFormat,
 				// Offload secret creation options
 				OffloadVSphereUsername: opts.OffloadVSphereUsername,
 				OffloadVSpherePassword: opts.OffloadVSpherePassword,
@@ -229,8 +243,10 @@ func Create(ctx context.Context, opts CreatePlanOptions) error {
 				return fmt.Errorf("failed to create storage map from pairs: %v", err)
 			}
 			opts.StorageMapping = storageMapName
-			createdStorageMap = true
-			fmt.Printf("Created storage mapping '%s' from provided pairs\n", storageMapName)
+			if !opts.DryRun {
+				createdStorageMap = true
+				fmt.Printf("Created storage mapping '%s' from provided pairs\n", storageMapName)
+			}
 		} else {
 			// Create default storage mapping using existing logic
 			storageMapName, err := storage.CreateStorageMap(ctx, storage.StorageMapperOptions{
@@ -242,8 +258,11 @@ func Create(ctx context.Context, opts CreatePlanOptions) error {
 				TargetProviderNamespace:   opts.TargetProviderNamespace,
 				ConfigFlags:               opts.ConfigFlags,
 				InventoryURL:              opts.InventoryURL,
+				InventoryInsecureSkipTLS:  opts.InventoryInsecureSkipTLS,
 				PlanVMNames:               planVMNames,
 				DefaultTargetStorageClass: opts.DefaultTargetStorageClass,
+				DryRun:                    opts.DryRun,
+				OutputFormat:              opts.OutputFormat,
 			})
 			if err != nil {
 				// Clean up the network map if we created it
@@ -255,7 +274,9 @@ func Create(ctx context.Context, opts CreatePlanOptions) error {
 				return fmt.Errorf("failed to create default storage map: %v", err)
 			}
 			opts.StorageMapping = storageMapName
-			createdStorageMap = true
+			if !opts.DryRun {
+				createdStorageMap = true
+			}
 		}
 	}
 
@@ -305,6 +326,10 @@ func Create(ctx context.Context, opts CreatePlanOptions) error {
 	}
 	planObj.Kind = "Plan"
 	planObj.APIVersion = forkliftv1beta1.SchemeGroupVersion.String()
+
+	if opts.DryRun {
+		return output.OutputResource(planObj, opts.OutputFormat)
+	}
 
 	// Convert Plan object to Unstructured
 	unstructuredPlan, err := runtime.DefaultUnstructuredConverter.ToUnstructured(planObj)

--- a/pkg/cmd/create/plan/storage/factory.go
+++ b/pkg/cmd/create/plan/storage/factory.go
@@ -33,6 +33,7 @@ import (
 	vsphereMapper "github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/storage/mapper/vsphere"
 	"github.com/yaacov/kubectl-mtv/pkg/cmd/get/inventory"
 	"github.com/yaacov/kubectl-mtv/pkg/util/client"
+	"github.com/yaacov/kubectl-mtv/pkg/util/output"
 )
 
 // StorageMapperInterface defines the interface that all provider-specific storage mappers must implement
@@ -60,6 +61,8 @@ type StorageMapperOptions struct {
 	InventoryInsecureSkipTLS  bool
 	PlanVMNames               []string
 	DefaultTargetStorageClass string
+	DryRun                    bool
+	OutputFormat              string
 }
 
 // CreateStorageMap creates a storage map using the new fetcher-based architecture
@@ -120,13 +123,23 @@ func CreateStorageMap(ctx context.Context, opts StorageMapperOptions) (string, e
 		return "", fmt.Errorf("failed to create storage pairs: %v", err)
 	}
 
+	if opts.DryRun {
+		storageMap, storageMapName, err := buildStorageMapObject(opts, storagePairs)
+		if err != nil {
+			return "", err
+		}
+		if err := output.OutputResource(storageMap, opts.OutputFormat); err != nil {
+			return "", err
+		}
+		return storageMapName, nil
+	}
+
 	// Create the storage map using the existing infrastructure
 	return createStorageMap(opts, storagePairs)
 }
 
-// createStorageMap helper function to create the actual storage map resource
-func createStorageMap(opts StorageMapperOptions, storagePairs []forkliftv1beta1.StoragePair) (string, error) {
-	// If no storage pairs, create a dummy pair
+// buildStorageMapObject builds a typed StorageMap (no API call).
+func buildStorageMapObject(opts StorageMapperOptions, storagePairs []forkliftv1beta1.StoragePair) (*forkliftv1beta1.StorageMap, string, error) {
 	if len(storagePairs) == 0 {
 		klog.V(4).Infof("DEBUG: No storage pairs found, creating dummy pair")
 		storagePairs = []forkliftv1beta1.StoragePair{
@@ -141,10 +154,8 @@ func createStorageMap(opts StorageMapperOptions, storagePairs []forkliftv1beta1.
 		}
 	}
 
-	// Create the storage map name
 	storageMapName := opts.Name + "-storage-map"
 
-	// Create StorageMap object
 	storageMap := &forkliftv1beta1.StorageMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      storageMapName,
@@ -170,6 +181,15 @@ func createStorageMap(opts StorageMapperOptions, storagePairs []forkliftv1beta1.
 	}
 	storageMap.Kind = "StorageMap"
 	storageMap.APIVersion = forkliftv1beta1.SchemeGroupVersion.String()
+	return storageMap, storageMapName, nil
+}
+
+// createStorageMap helper function to create the actual storage map resource
+func createStorageMap(opts StorageMapperOptions, storagePairs []forkliftv1beta1.StoragePair) (string, error) {
+	storageMap, storageMapName, err := buildStorageMapObject(opts, storagePairs)
+	if err != nil {
+		return "", err
+	}
 
 	// Convert to Unstructured
 	unstructuredMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(storageMap)

--- a/pkg/cmd/create/provider/create.go
+++ b/pkg/cmd/create/provider/create.go
@@ -13,6 +13,7 @@ import (
 	"github.com/yaacov/kubectl-mtv/pkg/cmd/create/provider/ova"
 	"github.com/yaacov/kubectl-mtv/pkg/cmd/create/provider/providerutil"
 	"github.com/yaacov/kubectl-mtv/pkg/cmd/create/provider/vsphere"
+	"github.com/yaacov/kubectl-mtv/pkg/util/output"
 
 	forkliftv1beta1 "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -53,6 +54,15 @@ func Create(configFlags *genericclioptions.ConfigFlags, providerType string, opt
 	// Handle any errors that occurred during provider creation
 	if err != nil {
 		return fmt.Errorf("failed to prepare provider: %v", err)
+	}
+
+	if options.DryRun {
+		if secretResource != nil {
+			if err := output.OutputResource(secretResource, options.OutputFormat); err != nil {
+				return err
+			}
+		}
+		return output.OutputResource(providerResource, options.OutputFormat)
 	}
 
 	// Display the creation results to the user

--- a/pkg/cmd/create/provider/ec2/ec2.go
+++ b/pkg/cmd/create/provider/ec2/ec2.go
@@ -162,8 +162,25 @@ func CreateProvider(configFlags *genericclioptions.ConfigFlags, options provider
 	var createdSecret *corev1.Secret
 	var err error
 
+	if options.DryRun {
+		if options.Secret == "" {
+			createdSecret = buildSecret(options.Namespace, options.Name,
+				options.Username, options.Password, providerURL, options.CACert, options.EC2Region, options.InsecureSkipTLS,
+				options.EC2TargetAccessKeyID, options.EC2TargetSecretKey)
+			provider.Spec.Secret = corev1.ObjectReference{
+				Name:      createdSecret.Name,
+				Namespace: createdSecret.Namespace,
+			}
+		} else {
+			provider.Spec.Secret = corev1.ObjectReference{
+				Name:      options.Secret,
+				Namespace: options.Namespace,
+			}
+		}
+		return provider, createdSecret, nil
+	}
+
 	if options.Secret == "" {
-		// Pass the providerURL (which may be default or custom) to secret creation
 		createdSecret, err = createSecret(configFlags, options.Namespace, options.Name,
 			options.Username, options.Password, providerURL, options.CACert, options.EC2Region, options.InsecureSkipTLS,
 			options.EC2TargetAccessKeyID, options.EC2TargetSecretKey)

--- a/pkg/cmd/create/provider/ec2/secrets.go
+++ b/pkg/cmd/create/provider/ec2/secrets.go
@@ -12,16 +12,8 @@ import (
 	"github.com/yaacov/kubectl-mtv/pkg/util/client"
 )
 
-// Helper function to create an EC2 secret
-func createSecret(configFlags *genericclioptions.ConfigFlags, namespace, providerName, accessKeyID, secretAccessKey, url, cacert, region string, insecureSkipTLS bool, targetAccessKeyID, targetSecretAccessKey string) (*corev1.Secret, error) {
-	// Get the Kubernetes client using configFlags
-	k8sClient, err := client.GetKubernetesClientset(configFlags)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create kubernetes client: %v", err)
-	}
-
-	// Create secret data without base64 encoding (the API handles this automatically)
-	// URL is always included (either custom or default AWS endpoint)
+// buildSecret returns an EC2 provider Secret without submitting it to the API.
+func buildSecret(namespace, providerName, accessKeyID, secretAccessKey, url, cacert, region string, insecureSkipTLS bool, targetAccessKeyID, targetSecretAccessKey string) *corev1.Secret {
 	secretData := map[string][]byte{
 		"accessKeyId":     []byte(accessKeyID),
 		"secretAccessKey": []byte(secretAccessKey),
@@ -29,7 +21,6 @@ func createSecret(configFlags *genericclioptions.ConfigFlags, namespace, provide
 		"region":          []byte(region),
 	}
 
-	// Add optional fields
 	if insecureSkipTLS {
 		secretData["insecureSkipVerify"] = []byte("true")
 	}
@@ -37,7 +28,6 @@ func createSecret(configFlags *genericclioptions.ConfigFlags, namespace, provide
 		secretData["cacert"] = []byte(cacert)
 	}
 
-	// Add cross-account migration credentials (optional)
 	if targetAccessKeyID != "" {
 		secretData["targetAccessKeyId"] = []byte(targetAccessKeyID)
 	}
@@ -45,14 +35,14 @@ func createSecret(configFlags *genericclioptions.ConfigFlags, namespace, provide
 		secretData["targetSecretAccessKey"] = []byte(targetSecretAccessKey)
 	}
 
-	// Generate a name prefix for the secret
-	secretName := fmt.Sprintf("%s-ec2-", providerName)
-
-	// Create the secret object directly as a typed Secret
-	secret := &corev1.Secret{
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: secretName,
-			Namespace:    namespace,
+			Name:      fmt.Sprintf("%s-ec2-credentials", providerName),
+			Namespace: namespace,
 			Labels: map[string]string{
 				"createdForProviderType": "ec2",
 				"createdForResourceType": "providers",
@@ -61,6 +51,19 @@ func createSecret(configFlags *genericclioptions.ConfigFlags, namespace, provide
 		Data: secretData,
 		Type: corev1.SecretTypeOpaque,
 	}
+}
+
+// createSecret creates an EC2 secret reusing the same object shape as buildSecret.
+// It swaps the deterministic Name for a GenerateName so the API server assigns a unique suffix.
+func createSecret(configFlags *genericclioptions.ConfigFlags, namespace, providerName, accessKeyID, secretAccessKey, url, cacert, region string, insecureSkipTLS bool, targetAccessKeyID, targetSecretAccessKey string) (*corev1.Secret, error) {
+	k8sClient, err := client.GetKubernetesClientset(configFlags)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client: %v", err)
+	}
+
+	secret := buildSecret(namespace, providerName, accessKeyID, secretAccessKey, url, cacert, region, insecureSkipTLS, targetAccessKeyID, targetSecretAccessKey)
+	secret.Name = ""
+	secret.GenerateName = fmt.Sprintf("%s-ec2-", providerName)
 
 	return k8sClient.CoreV1().Secrets(namespace).Create(context.Background(), secret, metav1.CreateOptions{})
 }

--- a/pkg/cmd/create/provider/generic/generic.go
+++ b/pkg/cmd/create/provider/generic/generic.go
@@ -165,6 +165,24 @@ func CreateProvider(configFlags *genericclioptions.ConfigFlags, options provider
 	var createdSecret *corev1.Secret
 	var err error
 
+	if options.DryRun {
+		if options.Secret == "" {
+			createdSecret = buildSecret(options.Namespace, options.Name,
+				options.Username, options.Password, options.URL, options.CACert, options.Token, options.InsecureSkipTLS,
+				options.DomainName, options.ProjectName, options.RegionName, providerType)
+			provider.Spec.Secret = corev1.ObjectReference{
+				Name:      createdSecret.Name,
+				Namespace: createdSecret.Namespace,
+			}
+		} else {
+			provider.Spec.Secret = corev1.ObjectReference{
+				Name:      options.Secret,
+				Namespace: options.Namespace,
+			}
+		}
+		return provider, createdSecret, nil
+	}
+
 	if options.Secret == "" {
 		createdSecret, err = createSecret(configFlags, options.Namespace, options.Name,
 			options.Username, options.Password, options.URL, options.CACert, options.Token, options.InsecureSkipTLS,

--- a/pkg/cmd/create/provider/generic/secrets.go
+++ b/pkg/cmd/create/provider/generic/secrets.go
@@ -13,21 +13,14 @@ import (
 	"github.com/yaacov/kubectl-mtv/pkg/util/client"
 )
 
-// createSecret creates a secret for generic providers (oVirt, OpenStack)
-func createSecret(configFlags *genericclioptions.ConfigFlags, namespace, providerName, user, password, url, cacert, token string, insecureSkipTLS bool, domainName, projectName, regionName, providerType string) (*corev1.Secret, error) {
-	c, err := client.GetDynamicClient(configFlags)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get client: %v", err)
-	}
-
+// buildSecret returns a secret for generic providers (oVirt) without submitting it to the API.
+func buildSecret(namespace, providerName, user, password, url, cacert, token string, insecureSkipTLS bool, domainName, projectName, regionName, providerType string) *corev1.Secret {
 	secretName := fmt.Sprintf("%s-provider-secret", providerName)
 
-	// Prepare secret data
 	secretData := map[string][]byte{
 		"url": []byte(url),
 	}
 
-	// Add authentication data based on what's provided
 	if token != "" {
 		secretData["token"] = []byte(token)
 	} else {
@@ -35,17 +28,14 @@ func createSecret(configFlags *genericclioptions.ConfigFlags, namespace, provide
 		secretData["password"] = []byte(password)
 	}
 
-	// Add CA certificate if provided
 	if cacert != "" {
 		secretData["cacert"] = []byte(cacert)
 	}
 
-	// Add insecureSkipVerify if true
 	if insecureSkipTLS {
 		secretData["insecureSkipVerify"] = []byte("true")
 	}
 
-	// Add OpenStack specific fields if provided
 	if providerType == "openstack" {
 		if domainName != "" {
 			secretData["domainName"] = []byte(domainName)
@@ -58,7 +48,11 @@ func createSecret(configFlags *genericclioptions.ConfigFlags, namespace, provide
 		}
 	}
 
-	secret := &corev1.Secret{
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: namespace,
@@ -66,6 +60,16 @@ func createSecret(configFlags *genericclioptions.ConfigFlags, namespace, provide
 		Type: corev1.SecretTypeOpaque,
 		Data: secretData,
 	}
+}
+
+// createSecret creates a secret for generic providers (oVirt, OpenStack)
+func createSecret(configFlags *genericclioptions.ConfigFlags, namespace, providerName, user, password, url, cacert, token string, insecureSkipTLS bool, domainName, projectName, regionName, providerType string) (*corev1.Secret, error) {
+	c, err := client.GetDynamicClient(configFlags)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get client: %v", err)
+	}
+
+	secret := buildSecret(namespace, providerName, user, password, url, cacert, token, insecureSkipTLS, domainName, projectName, regionName, providerType)
 
 	// Convert secret to unstructured
 	unstructSecret, err := runtime.DefaultUnstructuredConverter.ToUnstructured(secret)

--- a/pkg/cmd/create/provider/hyperv/hyperv.go
+++ b/pkg/cmd/create/provider/hyperv/hyperv.go
@@ -118,8 +118,26 @@ func CreateProvider(configFlags *genericclioptions.ConfigFlags, options provider
 	var createdSecret *corev1.Secret
 	var err error
 
+	if options.DryRun {
+		if options.Secret == "" {
+			createdSecret, err = buildSecret(options.Namespace, options.Name, options)
+			if err != nil {
+				return nil, nil, err
+			}
+			provider.Spec.Secret = corev1.ObjectReference{
+				Name:      createdSecret.Name,
+				Namespace: createdSecret.Namespace,
+			}
+		} else {
+			provider.Spec.Secret = corev1.ObjectReference{
+				Name:      options.Secret,
+				Namespace: options.Namespace,
+			}
+		}
+		return provider, createdSecret, nil
+	}
+
 	if options.Secret == "" {
-		// Create a new secret if none is provided
 		createdSecret, err = createSecret(configFlags, options.Namespace, options.Name, options)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create HyperV secret: %v", err)
@@ -130,7 +148,6 @@ func CreateProvider(configFlags *genericclioptions.ConfigFlags, options provider
 			Namespace: createdSecret.Namespace,
 		}
 	} else {
-		// Use the existing secret
 		provider.Spec.Secret = corev1.ObjectReference{
 			Name:      options.Secret,
 			Namespace: options.Namespace,

--- a/pkg/cmd/create/provider/hyperv/secrets.go
+++ b/pkg/cmd/create/provider/hyperv/secrets.go
@@ -15,20 +15,12 @@ import (
 	"github.com/yaacov/kubectl-mtv/pkg/util/client"
 )
 
-// Helper function to create a HyperV secret
-func createSecret(configFlags *genericclioptions.ConfigFlags, namespace, providerName string, options providerutil.ProviderOptions) (*corev1.Secret, error) {
-	// Get the Kubernetes client using configFlags
-	k8sClient, err := client.GetKubernetesClientset(configFlags)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create kubernetes client: %v", err)
-	}
-
-	// Validate required credentials
+// buildSecret returns a HyperV provider Secret without submitting it to the API.
+func buildSecret(namespace, providerName string, options providerutil.ProviderOptions) (*corev1.Secret, error) {
 	if options.Username == "" || options.Password == "" {
 		return nil, fmt.Errorf("username and password are required for HyperV provider")
 	}
 
-	// Create secret data without base64 encoding (the API handles this automatically)
 	secretData := map[string][]byte{
 		"username": []byte(options.Username),
 		"password": []byte(options.Password),
@@ -49,14 +41,14 @@ func createSecret(configFlags *genericclioptions.ConfigFlags, namespace, provide
 		secretData["cacert"] = []byte(options.CACert)
 	}
 
-	// Generate a name prefix for the secret
-	secretName := fmt.Sprintf("%s-hyperv-", providerName)
-
-	// Create the secret object directly as a typed Secret
-	secret := &corev1.Secret{
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: secretName,
-			Namespace:    namespace,
+			Name:      fmt.Sprintf("%s-hyperv-credentials", providerName),
+			Namespace: namespace,
 			Labels: map[string]string{
 				"createdForProviderType": "hyperv",
 				"createdForResourceType": "providers",
@@ -64,7 +56,23 @@ func createSecret(configFlags *genericclioptions.ConfigFlags, namespace, provide
 		},
 		Data: secretData,
 		Type: corev1.SecretTypeOpaque,
+	}, nil
+}
+
+// createSecret creates a HyperV secret reusing the same object shape as buildSecret.
+// It swaps the deterministic Name for a GenerateName so the API server assigns a unique suffix.
+func createSecret(configFlags *genericclioptions.ConfigFlags, namespace, providerName string, options providerutil.ProviderOptions) (*corev1.Secret, error) {
+	k8sClient, err := client.GetKubernetesClientset(configFlags)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client: %v", err)
 	}
+
+	secret, err := buildSecret(namespace, providerName, options)
+	if err != nil {
+		return nil, err
+	}
+	secret.Name = ""
+	secret.GenerateName = fmt.Sprintf("%s-hyperv-", providerName)
 
 	return k8sClient.CoreV1().Secrets(namespace).Create(context.Background(), secret, metav1.CreateOptions{})
 }

--- a/pkg/cmd/create/provider/openshift/openshift.go
+++ b/pkg/cmd/create/provider/openshift/openshift.go
@@ -110,31 +110,41 @@ func CreateProvider(configFlags *genericclioptions.ConfigFlags, options provider
 	var err error
 
 	if options.Token != "" {
-		createdSecret, err = createSecret(configFlags, options.Namespace, options.Name,
-			options.URL, options.Token, options.CACert, options.InsecureSkipTLS)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create vSphere secret: %v", err)
-		}
-
-		// If token is provided
 		if options.Secret != "" {
-			// Use the provided secret if specified alongside the token
 			provider.Spec.Secret = corev1.ObjectReference{
 				Name:      options.Secret,
 				Namespace: options.Namespace,
 			}
 		} else {
-			// Create a new secret if no existing secret is specified
-			createdSecret, err = createSecret(configFlags, options.Namespace, options.Name, options.URL, options.Token, options.CACert, options.InsecureSkipTLS)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to create OpenShift secret: %v", err)
-			}
+			if options.DryRun {
+				createdSecret = buildSecret(options.Namespace, options.Name,
+					options.URL, options.Token, options.CACert, options.InsecureSkipTLS)
+				provider.Spec.Secret = corev1.ObjectReference{
+					Name:      createdSecret.Name,
+					Namespace: createdSecret.Namespace,
+				}
+			} else {
+				createdSecret, err = createSecret(configFlags, options.Namespace, options.Name,
+					options.URL, options.Token, options.CACert, options.InsecureSkipTLS)
+				if err != nil {
+					return nil, nil, fmt.Errorf("failed to create OpenShift secret: %v", err)
+				}
 
-			provider.Spec.Secret = corev1.ObjectReference{
-				Name:      createdSecret.Name,
-				Namespace: createdSecret.Namespace,
+				provider.Spec.Secret = corev1.ObjectReference{
+					Name:      createdSecret.Name,
+					Namespace: createdSecret.Namespace,
+				}
 			}
 		}
+	} else if options.Secret != "" {
+		provider.Spec.Secret = corev1.ObjectReference{
+			Name:      options.Secret,
+			Namespace: options.Namespace,
+		}
+	}
+
+	if options.DryRun {
+		return provider, createdSecret, nil
 	}
 
 	// Create the provider

--- a/pkg/cmd/create/provider/openshift/secrets.go
+++ b/pkg/cmd/create/provider/openshift/secrets.go
@@ -12,20 +12,12 @@ import (
 	"github.com/yaacov/kubectl-mtv/pkg/util/client"
 )
 
-// Helper function to create an OpenShift secret
-func createSecret(configFlags *genericclioptions.ConfigFlags, namespace, providerName, url, token, cacert string, insecureSkipTLS bool) (*corev1.Secret, error) {
-	// Get the Kubernetes client using configFlags
-	k8sClient, err := client.GetKubernetesClientset(configFlags)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create kubernetes client: %v", err)
-	}
-
-	// Create secret data without base64 encoding (the API handles this automatically)
+// buildSecret returns an OpenShift provider Secret without submitting it to the API.
+func buildSecret(namespace, providerName, url, token, cacert string, insecureSkipTLS bool) *corev1.Secret {
 	secretData := map[string][]byte{
 		"token": []byte(token),
 		"url":   []byte(url),
 	}
-	// Add optional fields
 	if insecureSkipTLS {
 		secretData["insecureSkipVerify"] = []byte("true")
 	}
@@ -33,14 +25,14 @@ func createSecret(configFlags *genericclioptions.ConfigFlags, namespace, provide
 		secretData["cacert"] = []byte(cacert)
 	}
 
-	// Generate a name prefix for the secret
-	secretName := fmt.Sprintf("%s-openshift-", providerName)
-
-	// Create the secret object directly as a typed Secret
-	secret := &corev1.Secret{
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: secretName,
-			Namespace:    namespace,
+			Name:      fmt.Sprintf("%s-openshift-credentials", providerName),
+			Namespace: namespace,
 			Labels: map[string]string{
 				"createdForProviderType": "openshift",
 				"createdForResourceType": "providers",
@@ -49,6 +41,19 @@ func createSecret(configFlags *genericclioptions.ConfigFlags, namespace, provide
 		Data: secretData,
 		Type: corev1.SecretTypeOpaque,
 	}
+}
+
+// createSecret creates an OpenShift secret reusing the same object shape as buildSecret.
+// It swaps the deterministic Name for a GenerateName so the API server assigns a unique suffix.
+func createSecret(configFlags *genericclioptions.ConfigFlags, namespace, providerName, url, token, cacert string, insecureSkipTLS bool) (*corev1.Secret, error) {
+	k8sClient, err := client.GetKubernetesClientset(configFlags)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client: %v", err)
+	}
+
+	secret := buildSecret(namespace, providerName, url, token, cacert, insecureSkipTLS)
+	secret.Name = ""
+	secret.GenerateName = fmt.Sprintf("%s-openshift-", providerName)
 
 	return k8sClient.CoreV1().Secrets(namespace).Create(context.Background(), secret, metav1.CreateOptions{})
 }

--- a/pkg/cmd/create/provider/openstack/openstack.go
+++ b/pkg/cmd/create/provider/openstack/openstack.go
@@ -163,15 +163,30 @@ func CreateProvider(configFlags *genericclioptions.ConfigFlags, options provider
 	var createdSecret *corev1.Secret
 	var err error
 
-	// Handle secret creation
+	if options.DryRun {
+		if options.Secret != "" {
+			provider.Spec.Secret = corev1.ObjectReference{
+				Name:      options.Secret,
+				Namespace: options.Namespace,
+			}
+		} else {
+			createdSecret = buildSecret(options.Namespace, options.Name,
+				options.Username, options.Password, options.URL, options.CACert, options.Token,
+				options.InsecureSkipTLS, options.DomainName, options.ProjectName, options.RegionName)
+			provider.Spec.Secret = corev1.ObjectReference{
+				Name:      createdSecret.Name,
+				Namespace: createdSecret.Namespace,
+			}
+		}
+		return provider, createdSecret, nil
+	}
+
 	if options.Secret != "" {
-		// Use existing secret
 		provider.Spec.Secret = corev1.ObjectReference{
 			Name:      options.Secret,
 			Namespace: options.Namespace,
 		}
 	} else {
-		// Create new secret
 		createdSecret, err = createSecret(configFlags, options.Namespace, options.Name,
 			options.Username, options.Password, options.URL, options.CACert, options.Token,
 			options.InsecureSkipTLS, options.DomainName, options.ProjectName, options.RegionName)

--- a/pkg/cmd/create/provider/openstack/secrets.go
+++ b/pkg/cmd/create/provider/openstack/secrets.go
@@ -13,40 +13,29 @@ import (
 	"github.com/yaacov/kubectl-mtv/pkg/util/client"
 )
 
-// createSecret creates a secret for OpenStack providers with correct field names
-func createSecret(configFlags *genericclioptions.ConfigFlags, namespace, providerName, username, password, url, cacert, token string, insecureSkipTLS bool, domainName, projectName, regionName string) (*corev1.Secret, error) {
-	c, err := client.GetDynamicClient(configFlags)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get client: %v", err)
-	}
-
+// buildSecret returns an OpenStack provider Secret without submitting it to the API.
+func buildSecret(namespace, providerName, username, password, url, cacert, token string, insecureSkipTLS bool, domainName, projectName, regionName string) *corev1.Secret {
 	secretName := fmt.Sprintf("%s-openstack-secret", providerName)
 
-	// Prepare secret data
 	secretData := map[string][]byte{
 		"url": []byte(url),
 	}
 
-	// Add authentication data based on what's provided
 	if token != "" {
 		secretData["token"] = []byte(token)
 	} else {
-		// Use 'username' instead of 'user' for OpenStack
 		secretData["username"] = []byte(username)
 		secretData["password"] = []byte(password)
 	}
 
-	// Add CA certificate if provided
 	if cacert != "" {
 		secretData["cacert"] = []byte(cacert)
 	}
 
-	// Add insecureSkipVerify if true
 	if insecureSkipTLS {
 		secretData["insecureSkipVerify"] = []byte("true")
 	}
 
-	// Add OpenStack specific fields
 	if domainName != "" {
 		secretData["domainName"] = []byte(domainName)
 	}
@@ -57,7 +46,11 @@ func createSecret(configFlags *genericclioptions.ConfigFlags, namespace, provide
 		secretData["regionName"] = []byte(regionName)
 	}
 
-	secret := &corev1.Secret{
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: namespace,
@@ -69,6 +62,16 @@ func createSecret(configFlags *genericclioptions.ConfigFlags, namespace, provide
 		Type: corev1.SecretTypeOpaque,
 		Data: secretData,
 	}
+}
+
+// createSecret creates a secret for OpenStack providers with correct field names
+func createSecret(configFlags *genericclioptions.ConfigFlags, namespace, providerName, username, password, url, cacert, token string, insecureSkipTLS bool, domainName, projectName, regionName string) (*corev1.Secret, error) {
+	c, err := client.GetDynamicClient(configFlags)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get client: %w", err)
+	}
+
+	secret := buildSecret(namespace, providerName, username, password, url, cacert, token, insecureSkipTLS, domainName, projectName, regionName)
 
 	// Convert secret to unstructured
 	unstructSecret, err := runtime.DefaultUnstructuredConverter.ToUnstructured(secret)

--- a/pkg/cmd/create/provider/ova/ova.go
+++ b/pkg/cmd/create/provider/ova/ova.go
@@ -135,8 +135,23 @@ func CreateProvider(configFlags *genericclioptions.ConfigFlags, options provider
 	var createdSecret *corev1.Secret
 	var err error
 
+	if options.DryRun {
+		if options.Secret == "" {
+			createdSecret = buildSecret(options.Namespace, options.Name, options.URL)
+			provider.Spec.Secret = corev1.ObjectReference{
+				Name:      createdSecret.Name,
+				Namespace: createdSecret.Namespace,
+			}
+		} else {
+			provider.Spec.Secret = corev1.ObjectReference{
+				Name:      options.Secret,
+				Namespace: options.Namespace,
+			}
+		}
+		return provider, createdSecret, nil
+	}
+
 	if options.Secret == "" {
-		// Create a new secret if none is provided
 		createdSecret, err = createSecret(configFlags, options.Namespace, options.Name, options.URL)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create OVA secret: %v", err)
@@ -147,7 +162,6 @@ func CreateProvider(configFlags *genericclioptions.ConfigFlags, options provider
 			Namespace: createdSecret.Namespace,
 		}
 	} else {
-		// Use the existing secret
 		provider.Spec.Secret = corev1.ObjectReference{
 			Name:      options.Secret,
 			Namespace: options.Namespace,

--- a/pkg/cmd/create/provider/ova/secrets.go
+++ b/pkg/cmd/create/provider/ova/secrets.go
@@ -12,27 +12,19 @@ import (
 	"github.com/yaacov/kubectl-mtv/pkg/util/client"
 )
 
-// Helper function to create an OVA secret
-func createSecret(configFlags *genericclioptions.ConfigFlags, namespace, providerName, url string) (*corev1.Secret, error) {
-	// Get the Kubernetes client using configFlags
-	k8sClient, err := client.GetKubernetesClientset(configFlags)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create kubernetes client: %v", err)
-	}
-
-	// Create secret data without base64 encoding (the API handles this automatically)
+// buildSecret returns an OVA provider Secret without submitting it to the API.
+func buildSecret(namespace, providerName, url string) *corev1.Secret {
 	secretData := map[string][]byte{
 		"url": []byte(url),
 	}
-
-	// Generate a name prefix for the secret
-	secretName := fmt.Sprintf("%s-ova-", providerName)
-
-	// Create the secret object directly as a typed Secret
-	secret := &corev1.Secret{
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: secretName,
-			Namespace:    namespace,
+			Name:      fmt.Sprintf("%s-ova-credentials", providerName),
+			Namespace: namespace,
 			Labels: map[string]string{
 				"createdForProviderType": "ova",
 				"createdForResourceType": "providers",
@@ -41,6 +33,19 @@ func createSecret(configFlags *genericclioptions.ConfigFlags, namespace, provide
 		Data: secretData,
 		Type: corev1.SecretTypeOpaque,
 	}
+}
+
+// createSecret creates an OVA secret reusing the same object shape as buildSecret.
+// It swaps the deterministic Name for a GenerateName so the API server assigns a unique suffix.
+func createSecret(configFlags *genericclioptions.ConfigFlags, namespace, providerName, url string) (*corev1.Secret, error) {
+	k8sClient, err := client.GetKubernetesClientset(configFlags)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client: %v", err)
+	}
+
+	secret := buildSecret(namespace, providerName, url)
+	secret.Name = ""
+	secret.GenerateName = fmt.Sprintf("%s-ova-", providerName)
 
 	return k8sClient.CoreV1().Secrets(namespace).Create(context.Background(), secret, metav1.CreateOptions{})
 }

--- a/pkg/cmd/create/provider/providerutil/options.go
+++ b/pkg/cmd/create/provider/providerutil/options.go
@@ -34,4 +34,8 @@ type ProviderOptions struct {
 	EC2TargetAccessKeyID  string // Target account access key (cross-account migrations)
 	EC2TargetSecretKey    string // Target account secret key (cross-account migrations)
 	AutoTargetCredentials bool   // Auto-fetch target credentials from cluster
+	// DryRun when true builds Provider (and Secret if applicable) without calling the API
+	DryRun bool
+	// OutputFormat is the serialization format for dry-run output ("yaml" or "json")
+	OutputFormat string
 }

--- a/pkg/cmd/create/provider/vsphere/secrets.go
+++ b/pkg/cmd/create/provider/vsphere/secrets.go
@@ -12,22 +12,14 @@ import (
 	"github.com/yaacov/kubectl-mtv/pkg/util/client"
 )
 
-// Helper function to create a vSphere secret
-func createSecret(configFlags *genericclioptions.ConfigFlags, namespace, providerName, user, password, url, cacert string, insecureSkipTLS bool) (*corev1.Secret, error) {
-	// Get the Kubernetes client using configFlags
-	k8sClient, err := client.GetKubernetesClientset(configFlags)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create kubernetes client: %v", err)
-	}
-
-	// Create secret data without base64 encoding (the API handles this automatically)
+// buildSecret returns a vSphere provider Secret without submitting it to the API.
+func buildSecret(namespace, providerName, user, password, url, cacert string, insecureSkipTLS bool) *corev1.Secret {
 	secretData := map[string][]byte{
 		"user":     []byte(user),
 		"password": []byte(password),
 		"url":      []byte(url),
 	}
 
-	// Add optional fields
 	if insecureSkipTLS {
 		secretData["insecureSkipVerify"] = []byte("true")
 	}
@@ -35,14 +27,14 @@ func createSecret(configFlags *genericclioptions.ConfigFlags, namespace, provide
 		secretData["cacert"] = []byte(cacert)
 	}
 
-	// Generate a name prefix for the secret
-	secretName := fmt.Sprintf("%s-vsphere-", providerName)
-
-	// Create the secret object directly as a typed Secret
 	secret := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: secretName,
-			Namespace:    namespace,
+			Name:      fmt.Sprintf("%s-vsphere-credentials", providerName),
+			Namespace: namespace,
 			Labels: map[string]string{
 				"createdForProviderType": "vsphere",
 				"createdForResourceType": "providers",
@@ -51,6 +43,20 @@ func createSecret(configFlags *genericclioptions.ConfigFlags, namespace, provide
 		Data: secretData,
 		Type: corev1.SecretTypeOpaque,
 	}
+	return secret
+}
+
+// createSecret creates a vSphere secret reusing the same object shape as buildSecret.
+// It swaps the deterministic Name for a GenerateName so the API server assigns a unique suffix.
+func createSecret(configFlags *genericclioptions.ConfigFlags, namespace, providerName, user, password, url, cacert string, insecureSkipTLS bool) (*corev1.Secret, error) {
+	k8sClient, err := client.GetKubernetesClientset(configFlags)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client: %v", err)
+	}
+
+	secret := buildSecret(namespace, providerName, user, password, url, cacert, insecureSkipTLS)
+	secret.Name = ""
+	secret.GenerateName = fmt.Sprintf("%s-vsphere-", providerName)
 
 	return k8sClient.CoreV1().Secrets(namespace).Create(context.Background(), secret, metav1.CreateOptions{})
 }

--- a/pkg/cmd/create/provider/vsphere/vsphere.go
+++ b/pkg/cmd/create/provider/vsphere/vsphere.go
@@ -167,6 +167,23 @@ func CreateProvider(configFlags *genericclioptions.ConfigFlags, options provider
 	var createdSecret *corev1.Secret
 	var err error
 
+	if options.DryRun {
+		if options.Secret == "" {
+			createdSecret = buildSecret(options.Namespace, options.Name,
+				options.Username, options.Password, options.URL, options.CACert, options.InsecureSkipTLS)
+			provider.Spec.Secret = corev1.ObjectReference{
+				Name:      createdSecret.Name,
+				Namespace: createdSecret.Namespace,
+			}
+		} else {
+			provider.Spec.Secret = corev1.ObjectReference{
+				Name:      options.Secret,
+				Namespace: options.Namespace,
+			}
+		}
+		return provider, createdSecret, nil
+	}
+
 	if options.Secret == "" {
 		createdSecret, err = createSecret(configFlags, options.Namespace, options.Name,
 			options.Username, options.Password, options.URL, options.CACert, options.InsecureSkipTLS)

--- a/pkg/cmd/start/plan/start.go
+++ b/pkg/cmd/start/plan/start.go
@@ -2,7 +2,6 @@ package plan
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"time"
@@ -13,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"sigs.k8s.io/yaml"
 
 	forkliftv1beta1 "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/yaacov/kubectl-mtv/pkg/cmd/get/plan/status"
@@ -115,7 +113,7 @@ func Start(configFlags *genericclioptions.ConfigFlags, name, namespace string, c
 
 	// Handle dry-run mode
 	if dryRun {
-		return OutputMigrationCR(migration, outputFormat)
+		return output.OutputResource(migration, outputFormat)
 	}
 
 	// Convert Migration object to Unstructured
@@ -135,37 +133,5 @@ func Start(configFlags *genericclioptions.ConfigFlags, name, namespace string, c
 	if warm && cutoverTime != nil {
 		fmt.Fprintf(os.Stderr, "Cutover scheduled for: %s\n", output.FormatTimestamp(*cutoverTime, useUTC))
 	}
-	return nil
-}
-
-// OutputMigrationCR serializes a Migration CR to the specified format and outputs it to stdout
-func OutputMigrationCR(migration *forkliftv1beta1.Migration, outputFormat string) error {
-	if migration == nil {
-		return fmt.Errorf("migration CR is nil")
-	}
-
-	var output []byte
-	var err error
-
-	switch outputFormat {
-	case "yaml":
-		output, err = yaml.Marshal(migration)
-		if err != nil {
-			return fmt.Errorf("failed to marshal Migration to YAML: %v", err)
-		}
-		// Always prefix YAML with document separator for proper multi-document format
-		fmt.Print("---\n")
-		fmt.Print(string(output))
-		return nil
-	case "json":
-		output, err = json.MarshalIndent(migration, "", "  ")
-		if err != nil {
-			return fmt.Errorf("failed to marshal Migration to JSON: %v", err)
-		}
-	default:
-		return fmt.Errorf("unsupported output format: %s", outputFormat)
-	}
-
-	fmt.Print(string(output))
 	return nil
 }

--- a/pkg/mcp/tools/coerce_test.go
+++ b/pkg/mcp/tools/coerce_test.go
@@ -14,7 +14,7 @@ import (
 type testInput struct {
 	Command       string         `json:"command" jsonschema:"test command"`
 	AllNamespaces bool           `json:"all_namespaces,omitempty" jsonschema:"Query all namespaces"`
-	DryRun        bool           `json:"dry_run,omitempty" jsonschema:"Dry run mode"`
+	ShowCLI       bool           `json:"show_cli,omitempty" jsonschema:"Show CLI mode"`
 	Previous      bool           `json:"previous,omitempty" jsonschema:"Previous container"`
 	Name          string         `json:"name,omitempty" jsonschema:"Resource name"`
 	Flags         map[string]any `json:"flags,omitempty" jsonschema:"Additional flags"`
@@ -22,7 +22,7 @@ type testInput struct {
 
 func TestCoerceBooleans_ProperBooleans(t *testing.T) {
 	// Proper JSON booleans should pass through unchanged
-	data := json.RawMessage(`{"command":"get plan","all_namespaces":true,"dry_run":false}`)
+	data := json.RawMessage(`{"command":"get plan","all_namespaces":true,"show_cli":false}`)
 	result := CoerceBooleans[testInput](data)
 
 	var m map[string]any
@@ -32,8 +32,8 @@ func TestCoerceBooleans_ProperBooleans(t *testing.T) {
 	if m["all_namespaces"] != true {
 		t.Errorf("all_namespaces = %v, want true", m["all_namespaces"])
 	}
-	if m["dry_run"] != false {
-		t.Errorf("dry_run = %v, want false", m["dry_run"])
+	if m["show_cli"] != false {
+		t.Errorf("show_cli = %v, want false", m["show_cli"])
 	}
 }
 
@@ -75,15 +75,15 @@ func TestCoerceBooleans_StringFalse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			data := json.RawMessage(`{"command":"get plan","dry_run":` + tt.value + `}`)
+			data := json.RawMessage(`{"command":"get plan","show_cli":` + tt.value + `}`)
 			result := CoerceBooleans[testInput](data)
 
 			var m map[string]any
 			if err := json.Unmarshal(result, &m); err != nil {
 				t.Fatalf("Failed to unmarshal result: %v", err)
 			}
-			if m["dry_run"] != false {
-				t.Errorf("dry_run = %v (%T), want false (bool)", m["dry_run"], m["dry_run"])
+			if m["show_cli"] != false {
+				t.Errorf("show_cli = %v (%T), want false (bool)", m["show_cli"], m["show_cli"])
 			}
 		})
 	}
@@ -91,7 +91,7 @@ func TestCoerceBooleans_StringFalse(t *testing.T) {
 
 func TestCoerceBooleans_MixedCorrectAndString(t *testing.T) {
 	// Mix of proper booleans and string booleans
-	data := json.RawMessage(`{"command":"get plan","all_namespaces":true,"dry_run":"True","previous":"false"}`)
+	data := json.RawMessage(`{"command":"get plan","all_namespaces":true,"show_cli":"True","previous":"false"}`)
 	result := CoerceBooleans[testInput](data)
 
 	var m map[string]any
@@ -101,8 +101,8 @@ func TestCoerceBooleans_MixedCorrectAndString(t *testing.T) {
 	if m["all_namespaces"] != true {
 		t.Errorf("all_namespaces = %v, want true", m["all_namespaces"])
 	}
-	if m["dry_run"] != true {
-		t.Errorf("dry_run = %v, want true (coerced from \"True\")", m["dry_run"])
+	if m["show_cli"] != true {
+		t.Errorf("show_cli = %v, want true (coerced from \"True\")", m["show_cli"])
 	}
 	if m["previous"] != false {
 		t.Errorf("previous = %v, want false (coerced from \"false\")", m["previous"])
@@ -178,7 +178,7 @@ func TestCoerceBooleans_NonStructField(t *testing.T) {
 
 func TestCoerceBooleans_UnmarshalAfterCoerce(t *testing.T) {
 	// Verify that coerced data can be successfully unmarshaled into the typed struct
-	data := json.RawMessage(`{"command":"get plan","all_namespaces":"True","dry_run":"false"}`)
+	data := json.RawMessage(`{"command":"get plan","all_namespaces":"True","show_cli":"false"}`)
 	result := CoerceBooleans[testInput](data)
 
 	var input testInput
@@ -191,36 +191,36 @@ func TestCoerceBooleans_UnmarshalAfterCoerce(t *testing.T) {
 	if !input.AllNamespaces {
 		t.Error("AllNamespaces should be true after coercion from \"True\"")
 	}
-	if input.DryRun {
-		t.Error("DryRun should be false after coercion from \"false\"")
+	if input.ShowCLI {
+		t.Error("ShowCLI should be false after coercion from \"false\"")
 	}
 }
 
 // --- CoerceBooleans with real tool input types ---
 
 func TestCoerceBooleans_MTVReadInput(t *testing.T) {
-	data := json.RawMessage(`{"command":"get plan","dry_run":"FALSE"}`)
+	data := json.RawMessage(`{"command":"get plan","show_cli":"FALSE"}`)
 	result := CoerceBooleans[MTVReadInput](data)
 
 	var input MTVReadInput
 	if err := json.Unmarshal(result, &input); err != nil {
 		t.Fatalf("Failed to unmarshal: %v", err)
 	}
-	if input.DryRun {
-		t.Error("DryRun should be false")
+	if input.ShowCLI {
+		t.Error("ShowCLI should be false")
 	}
 }
 
 func TestCoerceBooleans_MTVWriteInput(t *testing.T) {
-	data := json.RawMessage(`{"command":"create plan","dry_run":"True"}`)
+	data := json.RawMessage(`{"command":"create plan","show_cli":"True"}`)
 	result := CoerceBooleans[MTVWriteInput](data)
 
 	var input MTVWriteInput
 	if err := json.Unmarshal(result, &input); err != nil {
 		t.Fatalf("Failed to unmarshal: %v", err)
 	}
-	if !input.DryRun {
-		t.Error("DryRun should be true")
+	if !input.ShowCLI {
+		t.Error("ShowCLI should be true")
 	}
 }
 

--- a/pkg/mcp/tools/mtv_read.go
+++ b/pkg/mcp/tools/mtv_read.go
@@ -16,7 +16,7 @@ type MTVReadInput struct {
 
 	Flags map[string]any `json:"flags,omitempty" jsonschema:"All parameters including positional args and options (e.g. name: \"my-plan\", provider: \"my-vsphere\", output: \"json\", namespace: \"ns\", query: \"where cpuCount > 4\")"`
 
-	DryRun bool `json:"dry_run,omitempty" jsonschema:"If true, does not execute. Returns the equivalent CLI command in the output field instead"`
+	ShowCLI bool `json:"show_cli,omitempty" jsonschema:"If true, does not execute. Returns the equivalent CLI command in the output field instead"`
 
 	Fields []string `json:"fields,omitempty" jsonschema:"Limit JSON to these top-level keys only (e.g. [name, id, concerns])"`
 }
@@ -117,9 +117,9 @@ func HandleMTVRead(registry *discovery.Registry) func(context.Context, *mcp.Call
 			return nil, nil, fmt.Errorf("unknown command '%s'. Available read commands: %s", input.Command, strings.Join(available, ", "))
 		}
 
-		// Enable dry run mode if requested
-		if input.DryRun {
-			ctx = util.WithDryRun(ctx, true)
+		// Enable show-CLI mode if requested
+		if input.ShowCLI {
+			ctx = util.WithShowCLI(ctx, true)
 		}
 
 		// Apply default output format for commands that support --output.

--- a/pkg/mcp/tools/mtv_read_test.go
+++ b/pkg/mcp/tools/mtv_read_test.go
@@ -431,9 +431,9 @@ func TestHandleMTVRead_ValidationErrors(t *testing.T) {
 	}
 }
 
-// --- Handler DryRun tests ---
+// --- Handler ShowCLI tests ---
 
-func TestHandleMTVRead_DryRun(t *testing.T) {
+func TestHandleMTVRead_ShowCLI(t *testing.T) {
 	registry := testRegistry()
 	handler := HandleMTVRead(registry)
 	ctx := context.Background()
@@ -454,7 +454,7 @@ func TestHandleMTVRead_DryRun(t *testing.T) {
 			input: MTVReadInput{
 				Command: "get plan",
 				Flags:   map[string]any{"namespace": "demo"},
-				DryRun:  true,
+				ShowCLI: true,
 			},
 			wantContains: []string{"kubectl-mtv", "get", "plan", "--namespace", "demo", "--output", "json"},
 		},
@@ -463,7 +463,7 @@ func TestHandleMTVRead_DryRun(t *testing.T) {
 			input: MTVReadInput{
 				Command: "get plan",
 				Flags:   map[string]any{"all_namespaces": true},
-				DryRun:  true,
+				ShowCLI: true,
 			},
 			wantContains: []string{"kubectl-mtv", "get", "plan", "--all-namespaces"},
 		},
@@ -472,7 +472,7 @@ func TestHandleMTVRead_DryRun(t *testing.T) {
 			input: MTVReadInput{
 				Command: "get inventory vm",
 				Flags:   map[string]any{"provider": "my-vsphere"},
-				DryRun:  true,
+				ShowCLI: true,
 			},
 			wantContains: []string{"kubectl-mtv", "get", "inventory", "vm", "--provider", "my-vsphere"},
 		},
@@ -481,7 +481,7 @@ func TestHandleMTVRead_DryRun(t *testing.T) {
 			input: MTVReadInput{
 				Command: "describe plan",
 				Flags:   map[string]any{"name": "my-plan", "namespace": "test-ns"},
-				DryRun:  true,
+				ShowCLI: true,
 			},
 			wantContains: []string{"kubectl-mtv", "describe", "plan", "--name", "my-plan", "--namespace", "test-ns"},
 		},
@@ -489,7 +489,7 @@ func TestHandleMTVRead_DryRun(t *testing.T) {
 			name: "health check",
 			input: MTVReadInput{
 				Command: "health",
-				DryRun:  true,
+				ShowCLI: true,
 			},
 			wantContains: []string{"kubectl-mtv", "health"},
 		},
@@ -498,7 +498,7 @@ func TestHandleMTVRead_DryRun(t *testing.T) {
 			input: MTVReadInput{
 				Command: "get inventory vm",
 				Flags:   map[string]any{"provider": "my-provider", "inventory_url": "http://localhost:9090"},
-				DryRun:  true,
+				ShowCLI: true,
 			},
 			wantContains: []string{"--inventory-url", "http://localhost:9090"},
 		},
@@ -507,7 +507,7 @@ func TestHandleMTVRead_DryRun(t *testing.T) {
 			input: MTVReadInput{
 				Command: "get inventory vm",
 				Flags:   map[string]any{"provider": "my-provider", "extended": true},
-				DryRun:  true,
+				ShowCLI: true,
 			},
 			wantContains: []string{"--extended"},
 		},
@@ -525,10 +525,10 @@ func TestHandleMTVRead_DryRun(t *testing.T) {
 				t.Fatalf("expected map[string]interface{}, got %T", data)
 			}
 
-			// In dry-run mode, the CLI command is in "output" (command field is stripped)
+			// In show-CLI mode, the CLI command is in "output" (command field is stripped)
 			output, ok := dataMap["output"].(string)
 			if !ok {
-				t.Fatal("response should have 'output' string field in dry-run mode")
+				t.Fatal("response should have 'output' string field in show-CLI mode")
 			}
 
 			// "command" field should NOT be present (stripped to prevent CLI mimicry)

--- a/pkg/mcp/tools/mtv_write.go
+++ b/pkg/mcp/tools/mtv_write.go
@@ -16,7 +16,7 @@ type MTVWriteInput struct {
 
 	Flags map[string]any `json:"flags,omitempty" jsonschema:"All parameters including positional args and options (e.g. name: \"my-provider\", type: \"vsphere\", url: \"https://vcenter/sdk\", namespace: \"ns\")"`
 
-	DryRun bool `json:"dry_run,omitempty" jsonschema:"If true, does not execute. Returns the equivalent CLI command in the output field instead"`
+	ShowCLI bool `json:"show_cli,omitempty" jsonschema:"If true, does not execute. Returns the equivalent CLI command in the output field instead"`
 }
 
 // GetMTVWriteTool returns the tool definition for read-write MTV commands.
@@ -59,9 +59,9 @@ func HandleMTVWrite(registry *discovery.Registry) func(context.Context, *mcp.Cal
 			return nil, nil, fmt.Errorf("unknown command '%s'. Available write commands: %s", input.Command, strings.Join(available, ", "))
 		}
 
-		// Enable dry run mode if requested
-		if input.DryRun {
-			ctx = util.WithDryRun(ctx, true)
+		// Enable show-CLI mode if requested
+		if input.ShowCLI {
+			ctx = util.WithShowCLI(ctx, true)
 		}
 
 		// Build command arguments (all params passed via flags)

--- a/pkg/mcp/tools/mtv_write_test.go
+++ b/pkg/mcp/tools/mtv_write_test.go
@@ -169,9 +169,9 @@ func TestHandleMTVWrite_ValidationErrors(t *testing.T) {
 	}
 }
 
-// --- Handler DryRun tests ---
+// --- Handler ShowCLI tests ---
 
-func TestHandleMTVWrite_DryRun(t *testing.T) {
+func TestHandleMTVWrite_ShowCLI(t *testing.T) {
 	registry := &discovery.Registry{
 		ReadOnly: map[string]*discovery.Command{
 			"get/plan": {Path: []string{"get", "plan"}, PathString: "get plan", Description: "Get plans"},
@@ -207,7 +207,7 @@ func TestHandleMTVWrite_DryRun(t *testing.T) {
 					"type": "vsphere",
 					"url":  "https://vcenter.example.com",
 				},
-				DryRun: true,
+				ShowCLI: true,
 			},
 			wantContains: []string{"kubectl-mtv", "create", "provider", "--name", "my-vsphere", "--type", "vsphere", "--url"},
 		},
@@ -216,7 +216,7 @@ func TestHandleMTVWrite_DryRun(t *testing.T) {
 			input: MTVWriteInput{
 				Command: "delete plan",
 				Flags:   map[string]any{"name": "old-plan", "namespace": "demo"},
-				DryRun:  true,
+				ShowCLI: true,
 			},
 			wantContains: []string{"kubectl-mtv", "delete", "plan", "old-plan", "--namespace", "demo"},
 		},
@@ -225,7 +225,7 @@ func TestHandleMTVWrite_DryRun(t *testing.T) {
 			input: MTVWriteInput{
 				Command: "start plan",
 				Flags:   map[string]any{"name": "my-plan"},
-				DryRun:  true,
+				ShowCLI: true,
 			},
 			wantContains: []string{"kubectl-mtv", "start", "plan", "my-plan"},
 		},
@@ -243,10 +243,10 @@ func TestHandleMTVWrite_DryRun(t *testing.T) {
 				t.Fatalf("expected map[string]interface{}, got %T", data)
 			}
 
-			// In dry-run mode, the CLI command is in "output" (command field is stripped)
+			// In show-CLI mode, the CLI command is in "output" (command field is stripped)
 			output, ok := dataMap["output"].(string)
 			if !ok {
-				t.Fatal("response should have 'output' string field in dry-run mode")
+				t.Fatal("response should have 'output' string field in show-CLI mode")
 			}
 
 			for _, want := range tt.wantContains {

--- a/pkg/mcp/util/util.go
+++ b/pkg/mcp/util/util.go
@@ -24,8 +24,8 @@ const (
 	kubeconfigTokenKey contextKey = "kubeconfig_token"
 	// kubeconfigServerKey is the context key for Kubernetes API server URL
 	kubeconfigServerKey contextKey = "kubeconfig_server"
-	// dryRunKey is the context key for dry run mode
-	dryRunKey contextKey = "dry_run"
+	// showCLIKey is the context key for show-CLI mode (returns CLI command without executing)
+	showCLIKey contextKey = "show_cli"
 )
 
 // WithKubeToken adds a Kubernetes token to the context
@@ -84,18 +84,18 @@ func WithKubeCredsFromHeaders(ctx context.Context, headers http.Header) context.
 	return ctx
 }
 
-// WithDryRun adds a dry run flag to the context
-func WithDryRun(ctx context.Context, dryRun bool) context.Context {
-	return context.WithValue(ctx, dryRunKey, dryRun)
+// WithShowCLI adds a show-CLI flag to the context
+func WithShowCLI(ctx context.Context, showCLI bool) context.Context {
+	return context.WithValue(ctx, showCLIKey, showCLI)
 }
 
-// GetDryRun retrieves the dry run flag from the context
-func GetDryRun(ctx context.Context) bool {
+// GetShowCLI retrieves the show-CLI flag from the context
+func GetShowCLI(ctx context.Context) bool {
 	if ctx == nil {
 		return false
 	}
-	dryRun, ok := ctx.Value(dryRunKey).(bool)
-	return ok && dryRun
+	showCLI, ok := ctx.Value(showCLIKey).(bool)
+	return ok && showCLI
 }
 
 // outputFormat stores the configured output format for MCP responses
@@ -225,7 +225,7 @@ var selfExePath = func() string {
 // If a server URL is present in the context, it will be passed via the --server flag.
 // If neither is present, it falls back to CLI default values, then to the default kubeconfig behavior.
 // Precedence: context (HTTP headers) > CLI defaults > kubeconfig (implicit).
-// If dry run mode is enabled in the context, it returns a teaching response instead of executing.
+// If show-CLI mode is enabled in the context, it returns a teaching response instead of executing.
 func RunKubectlMTVCommand(ctx context.Context, args []string) (string, error) {
 	// Always disable ANSI color codes -- MCP consumers are LLMs, not terminals
 	args = append([]string{"--no-color"}, args...)
@@ -263,10 +263,9 @@ func RunKubectlMTVCommand(ctx context.Context, args []string) (string, error) {
 		klog.V(2).Info("[auth] no explicit --token; falling back to kubeconfig")
 	}
 
-	// Check if we're in dry run mode
-	if GetDryRun(ctx) {
-		// In dry run mode, just return the command that would be executed
-		// The AI will explain it in context
+	// Check if we're in show-CLI mode
+	if GetShowCLI(ctx) {
+		// In show-CLI mode, just return the command that would be executed
 		cmdStr := formatShellCommand("kubectl-mtv", args)
 		response := CommandResponse{
 			Command:     cmdStr,
@@ -284,7 +283,7 @@ func RunKubectlMTVCommand(ctx context.Context, args []string) (string, error) {
 	}
 
 	// Resolve environment variable references for sensitive flags (e.g., $VCENTER_PASSWORD)
-	// This is done after dry run check so dry run shows $VAR syntax, not resolved values
+	// This is done after show-CLI check so show-CLI shows $VAR syntax, not resolved values
 	resolvedArgs, err := ResolveEnvVars(args)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve environment variables: %w", err)

--- a/pkg/mcp/util/util_test.go
+++ b/pkg/mcp/util/util_test.go
@@ -404,24 +404,24 @@ func TestWithKubeServer(t *testing.T) {
 	}
 }
 
-func TestWithDryRun(t *testing.T) {
+func TestWithShowCLI(t *testing.T) {
 	ctx := context.Background()
 
 	// Default is false
-	if GetDryRun(ctx) {
-		t.Error("fresh context should not have dry run enabled")
+	if GetShowCLI(ctx) {
+		t.Error("fresh context should not have show-CLI enabled")
 	}
 
-	// Enable dry run
-	ctx = WithDryRun(ctx, true)
-	if !GetDryRun(ctx) {
-		t.Error("dry run should be enabled after setting true")
+	// Enable show-CLI
+	ctx = WithShowCLI(ctx, true)
+	if !GetShowCLI(ctx) {
+		t.Error("show-CLI should be enabled after setting true")
 	}
 
-	// Disable dry run
-	ctx = WithDryRun(ctx, false)
-	if GetDryRun(ctx) {
-		t.Error("dry run should be disabled after setting false")
+	// Disable show-CLI
+	ctx = WithShowCLI(ctx, false)
+	if GetShowCLI(ctx) {
+		t.Error("show-CLI should be disabled after setting false")
 	}
 }
 
@@ -439,9 +439,9 @@ func TestGetKubeServer_NilContext(t *testing.T) {
 	}
 }
 
-func TestGetDryRun_NilContext(t *testing.T) {
-	if GetDryRun(nil) { //nolint:staticcheck // intentionally testing nil context behavior
-		t.Error("nil context should return false for dry run")
+func TestGetShowCLI_NilContext(t *testing.T) {
+	if GetShowCLI(nil) { //nolint:staticcheck // intentionally testing nil context behavior
+		t.Error("nil context should return false for show-CLI")
 	}
 }
 
@@ -574,8 +574,8 @@ func TestRunKubectlMTVCommand_DefaultCredsFallback(t *testing.T) {
 	SetDefaultKubeServer("https://cli-default.example.com:6443")
 	SetDefaultKubeToken("cli-default-token")
 
-	// Use dry run mode to capture the command without executing
-	ctx := WithDryRun(context.Background(), true)
+	// Use show-CLI mode to capture the command without executing
+	ctx := WithShowCLI(context.Background(), true)
 
 	result, err := RunKubectlMTVCommand(ctx, []string{"get", "plan"})
 	if err != nil {
@@ -611,7 +611,7 @@ func TestRunKubectlMTVCommand_ContextOverridesDefaults(t *testing.T) {
 	ctx := context.Background()
 	ctx = WithKubeServer(ctx, "https://header-override.example.com:6443")
 	ctx = WithKubeToken(ctx, "header-override-token")
-	ctx = WithDryRun(ctx, true)
+	ctx = WithShowCLI(ctx, true)
 
 	result, err := RunKubectlMTVCommand(ctx, []string{"get", "plan"})
 	if err != nil {
@@ -640,8 +640,8 @@ func TestRunKubectlMTVCommand_NoCredsWhenNoneSet(t *testing.T) {
 	SetDefaultKubeServer("")
 	SetDefaultKubeToken("")
 
-	// Use dry run mode with no context credentials
-	ctx := WithDryRun(context.Background(), true)
+	// Use show-CLI mode with no context credentials
+	ctx := WithShowCLI(context.Background(), true)
 
 	result, err := RunKubectlMTVCommand(ctx, []string{"get", "plan"})
 	if err != nil {

--- a/pkg/util/output/dryrun.go
+++ b/pkg/util/output/dryrun.go
@@ -1,0 +1,38 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+// OutputResource serializes a Kubernetes resource object to the specified format
+// and prints it to stdout. Supports "yaml" (default) and "json" formats.
+// YAML output is prefixed with "---\n" for multi-document compatibility.
+// Call multiple times to output multiple resources (e.g., Secret + Provider).
+func OutputResource(obj interface{}, format string) error {
+	if obj == nil {
+		return fmt.Errorf("resource object is nil")
+	}
+
+	switch format {
+	case "yaml", "":
+		data, err := yaml.Marshal(obj)
+		if err != nil {
+			return fmt.Errorf("failed to marshal resource to YAML: %v", err)
+		}
+		fmt.Print("---\n")
+		fmt.Print(string(data))
+		return nil
+	case "json":
+		data, err := json.MarshalIndent(obj, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal resource to JSON: %v", err)
+		}
+		fmt.Println(string(data))
+		return nil
+	default:
+		return fmt.Errorf("unsupported output format: %s. Valid formats are: json, yaml", format)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --dry-run preview with --output/-o (yaml default) and validation (--output only valid with --dry-run).
  * Added show-CLI mode to display generated kubectl-mtv commands without executing.

* **Improvements**
  * Dry-run/show-CLI support extended across create flows (providers, hooks, plans, hosts, mappings) with unified serialization.
  * CLI input/mode renamed from dry_run → show_cli for MCP tools.

* **Tests**
  * New end-to-end dry-run/show-CLI tests and Makefile target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->