### PR TITLE
pvc-chck

### DIFF
--- a/pkg/cmd/create/plan/storage/factory.go
+++ b/pkg/cmd/create/plan/storage/factory.go
@@ -141,17 +141,7 @@ func CreateStorageMap(ctx context.Context, opts StorageMapperOptions) (string, e
 // buildStorageMapObject builds a typed StorageMap (no API call).
 func buildStorageMapObject(opts StorageMapperOptions, storagePairs []forkliftv1beta1.StoragePair) (*forkliftv1beta1.StorageMap, string, error) {
 	if len(storagePairs) == 0 {
-		klog.V(4).Infof("DEBUG: No storage pairs found, creating dummy pair")
-		storagePairs = []forkliftv1beta1.StoragePair{
-			{
-				Source: ref.Ref{
-					Type: "default", // Use "default" type for dummy entry
-				},
-				Destination: forkliftv1beta1.DestinationStorage{
-					// Empty StorageClass means system default
-				},
-			},
-		}
+		klog.V(4).Infof("DEBUG: No storage pairs found, StorageMap will have an empty map")
 	}
 
 	storageMapName := opts.Name + "-storage-map"

--- a/pkg/cmd/create/plan/storage/fetchers/openshift/fetcher.go
+++ b/pkg/cmd/create/plan/storage/fetchers/openshift/fetcher.go
@@ -8,6 +8,7 @@ import (
 
 	forkliftv1beta1 "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/klog/v2"
 
@@ -24,170 +25,75 @@ func NewOpenShiftStorageFetcher() *OpenShiftStorageFetcher {
 	return &OpenShiftStorageFetcher{}
 }
 
-// FetchSourceStorages extracts storage references from OpenShift VMs
+// FetchSourceStorages extracts storage references from OpenShift VMs by looking
+// up the actual PVCs that back each VM volume. The PVC's spec.storageClassName
+// is the authoritative source -- it reflects the resolved SC even when the
+// dataVolumeTemplate didn't specify one explicitly.
 func (f *OpenShiftStorageFetcher) FetchSourceStorages(ctx context.Context, configFlags *genericclioptions.ConfigFlags, providerName, namespace, inventoryURL string, planVMNames []string, insecureSkipTLS bool) ([]ref.Ref, error) {
 	klog.V(4).Infof("OpenShift storage fetcher - extracting source storages for provider: %s", providerName)
 
-	// Get the provider object
 	provider, err := inventory.GetProviderByName(ctx, configFlags, providerName, namespace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get source provider: %v", err)
 	}
 
-	// Fetch storage inventory (StorageClasses in OpenShift) first to create ID-to-storage mapping
-	storageInventory, err := client.FetchProviderInventoryWithInsecure(ctx, configFlags, inventoryURL, provider, "storageclasses?detail=4", insecureSkipTLS)
+	// Build StorageClass lookup maps (name -> ID, ID -> inventory item).
+	storageIDToStorage, storageNameToID, err := fetchStorageClassMaps(ctx, configFlags, inventoryURL, provider, insecureSkipTLS)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch storage inventory: %v", err)
+		return nil, err
 	}
 
-	storageArray, ok := storageInventory.([]interface{})
-	if !ok {
-		return nil, fmt.Errorf("unexpected data format: expected array for storage inventory")
+	// Build PVC lookup map (namespace/name -> storageClassName).
+	pvcSCMap, err := fetchPVCStorageClassMap(ctx, configFlags, inventoryURL, provider, insecureSkipTLS)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch PVC inventory: %v", err)
 	}
 
-	// Create ID-to-storage and name-to-ID mappings for StorageClasses
-	storageIDToStorage := make(map[string]map[string]interface{})
-	storageNameToID := make(map[string]string)
-	for _, item := range storageArray {
-		if storage, ok := item.(map[string]interface{}); ok {
-			if storageID, ok := storage["id"].(string); ok {
-				storageIDToStorage[storageID] = storage
-				if storageName, ok := storage["name"].(string); ok {
-					storageNameToID[storageName] = storageID
-				}
-			}
-		}
-	}
-
-	klog.V(4).Infof("Available StorageClass mappings:")
-	for id, storageItem := range storageIDToStorage {
-		if name, ok := storageItem["name"].(string); ok {
-			klog.V(4).Infof("  %s -> %s", id, name)
-		}
-	}
-
-	// Fetch VMs inventory to get storage references from VMs
+	// Fetch VMs inventory.
 	vmsInventory, err := client.FetchProviderInventoryWithInsecure(ctx, configFlags, inventoryURL, provider, "vms?detail=4", insecureSkipTLS)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch VMs inventory: %v", err)
 	}
-
 	vmsArray, ok := vmsInventory.([]interface{})
 	if !ok {
 		return nil, fmt.Errorf("unexpected data format: expected array for VMs inventory")
 	}
 
-	// Extract storage IDs used by the plan VMs
-	storageIDSet := make(map[string]bool)
-	planVMSet := make(map[string]bool)
+	planVMSet := make(map[string]bool, len(planVMNames))
 	for _, vmName := range planVMNames {
 		planVMSet[vmName] = true
 	}
+
+	storageIDSet := make(map[string]bool)
 
 	for _, item := range vmsArray {
 		vm, ok := item.(map[string]interface{})
 		if !ok {
 			continue
 		}
-
-		vmName, ok := vm["name"].(string)
-		if !ok || !planVMSet[vmName] {
+		vmName, _ := vm["name"].(string)
+		if !planVMSet[vmName] {
 			continue
 		}
 
-		klog.V(4).Infof("Processing VM: %s", vmName)
+		vmNamespace, _ := query.GetValueByPathString(vm, "object.metadata.namespace")
+		vmNS, _ := vmNamespace.(string)
+		klog.V(4).Infof("Processing VM: %s (namespace: %s)", vmName, vmNS)
 
-		// Extract storage references from VM spec (OpenShift VMs use dataVolumeTemplates and volumes)
-		dataVolumeTemplates, err := query.GetValueByPathString(vm, "object.spec.dataVolumeTemplates")
-		if err == nil && dataVolumeTemplates != nil {
-			if dvtArray, ok := dataVolumeTemplates.([]interface{}); ok {
-				klog.V(4).Infof("VM %s has %d dataVolumeTemplates", vmName, len(dvtArray))
-				for _, dvtItem := range dvtArray {
-					if dvtMap, ok := dvtItem.(map[string]interface{}); ok {
-						// Look for storageClassName in spec.storageClassName
-						storageClassName, err := query.GetValueByPathString(dvtMap, "spec.storageClassName")
-						if err == nil && storageClassName != nil {
-							if scName, ok := storageClassName.(string); ok {
-								klog.V(4).Infof("Found explicit storageClassName: %s", scName)
-								if storageID, exists := storageNameToID[scName]; exists {
-									storageIDSet[storageID] = true
-								}
-							}
-						} else {
-							// No explicit storageClassName - check if this dataVolumeTemplate has storage requirements
-							// This indicates it uses the default storage class
-							storage, err := query.GetValueByPathString(dvtMap, "spec.storage")
-							if err == nil && storage != nil {
-								klog.V(4).Infof("Found dataVolumeTemplate with storage but no explicit storageClassName - using default storage class")
-								// Find the default storage class
-								for storageID, storageItem := range storageIDToStorage {
-									isDefaultValue, err := query.GetValueByPathString(storageItem, "object.metadata.annotations.storageclass.kubernetes.io/is-default-class")
-									if err == nil && isDefaultValue != nil {
-										if isDefault, ok := isDefaultValue.(string); ok && isDefault == "true" {
-											klog.V(4).Infof("Using default StorageClass for VM %s: %s", vmName, storageID)
-											storageIDSet[storageID] = true
-											break
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-
-		volumes, err := query.GetValueByPathString(vm, "object.spec.template.spec.volumes")
-		if err == nil && volumes != nil {
-			if volumesArray, ok := volumes.([]interface{}); ok {
-				klog.V(4).Infof("VM %s has %d volumes", vmName, len(volumesArray))
-				for _, volumeItem := range volumesArray {
-					if volumeMap, ok := volumeItem.(map[string]interface{}); ok {
-						// Check if this volume references a DataVolume (which may have storage class info)
-						dataVolume, err := query.GetValueByPathString(volumeMap, "dataVolume")
-						if err == nil && dataVolume != nil {
-							klog.V(4).Infof("Found volume with dataVolume reference in VM %s", vmName)
-							// The actual storage class info is in the dataVolumeTemplates we already processed
-						} else {
-							klog.V(4).Infof("Found volume in VM %s", vmName)
-						}
-					}
-				}
-			}
-		}
+		collectStorageFromVM(vm, vmNS, storageIDSet, storageNameToID, pvcSCMap)
 	}
 
 	klog.V(4).Infof("Final storageIDSet: %v", storageIDSet)
 
-	// If no storages found from VMs, still try to find a default storage class
-	// This handles cases where VMs exist but don't have explicit storage references
-	if len(storageIDSet) == 0 {
-		klog.V(4).Infof("No explicit storage found from VMs, looking for default storage class")
-		for storageID, storageItem := range storageIDToStorage {
-			isDefaultValue, err := query.GetValueByPathString(storageItem, "object.metadata.annotations.storageclass.kubernetes.io/is-default-class")
-			if err == nil && isDefaultValue != nil {
-				if isDefault, ok := isDefaultValue.(string); ok && isDefault == "true" {
-					klog.V(4).Infof("Found and using default StorageClass: %s", storageID)
-					storageIDSet[storageID] = true
-					break
-				}
-			}
-		}
-	}
-
-	// If still no storages found, return empty list
 	if len(storageIDSet) == 0 {
 		klog.V(4).Infof("No storages found from VMs")
 		return []ref.Ref{}, nil
 	}
 
-	// Build source storages list using the collected IDs
 	var sourceStorages []ref.Ref
 	for storageID := range storageIDSet {
 		if storageItem, exists := storageIDToStorage[storageID]; exists {
-			sourceStorage := ref.Ref{
-				ID: storageID,
-			}
+			sourceStorage := ref.Ref{ID: storageID}
 			if name, ok := storageItem["name"].(string); ok {
 				sourceStorage.Name = name
 			}
@@ -197,6 +103,140 @@ func (f *OpenShiftStorageFetcher) FetchSourceStorages(ctx context.Context, confi
 
 	klog.V(4).Infof("OpenShift storage fetcher - found %d source storages", len(sourceStorages))
 	return sourceStorages, nil
+}
+
+// fetchStorageClassMaps returns ID-to-item and name-to-ID maps for StorageClasses.
+func fetchStorageClassMaps(ctx context.Context, configFlags *genericclioptions.ConfigFlags, inventoryURL string, provider *unstructured.Unstructured, insecureSkipTLS bool) (map[string]map[string]interface{}, map[string]string, error) {
+	storageInventory, err := client.FetchProviderInventoryWithInsecure(ctx, configFlags, inventoryURL, provider, "storageclasses?detail=4", insecureSkipTLS)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to fetch storage inventory: %v", err)
+	}
+	storageArray, ok := storageInventory.([]interface{})
+	if !ok {
+		return nil, nil, fmt.Errorf("unexpected data format: expected array for storage inventory")
+	}
+
+	idToStorage := make(map[string]map[string]interface{}, len(storageArray))
+	nameToID := make(map[string]string, len(storageArray))
+	for _, item := range storageArray {
+		if sc, ok := item.(map[string]interface{}); ok {
+			if id, ok := sc["id"].(string); ok {
+				idToStorage[id] = sc
+				if name, ok := sc["name"].(string); ok {
+					nameToID[name] = id
+				}
+			}
+		}
+	}
+
+	klog.V(4).Infof("Available StorageClass mappings (%d):", len(idToStorage))
+	for id, sc := range idToStorage {
+		if name, ok := sc["name"].(string); ok {
+			klog.V(4).Infof("  %s -> %s", id, name)
+		}
+	}
+	return idToStorage, nameToID, nil
+}
+
+// fetchPVCStorageClassMap builds a "namespace/name" -> storageClassName map from
+// the PVC inventory. This is the reliable way to discover the resolved SC for
+// volumes that didn't specify one explicitly in the dataVolumeTemplate.
+func fetchPVCStorageClassMap(ctx context.Context, configFlags *genericclioptions.ConfigFlags, inventoryURL string, provider *unstructured.Unstructured, insecureSkipTLS bool) (map[string]string, error) {
+	pvcInventory, err := client.FetchProviderInventoryWithInsecure(ctx, configFlags, inventoryURL, provider, "persistentvolumeclaims?detail=4", insecureSkipTLS)
+	if err != nil {
+		return nil, err
+	}
+	pvcArray, ok := pvcInventory.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unexpected data format: expected array for PVC inventory")
+	}
+
+	pvcMap := make(map[string]string, len(pvcArray))
+	for _, item := range pvcArray {
+		pvc, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _ := pvc["name"].(string)
+		ns, _ := pvc["namespace"].(string)
+		if name == "" {
+			continue
+		}
+		scName, _ := query.GetValueByPathString(pvc, "object.spec.storageClassName")
+		if sc, ok := scName.(string); ok && sc != "" {
+			key := ns + "/" + name
+			pvcMap[key] = sc
+			klog.V(4).Infof("PVC %s -> storageClassName: %s", key, sc)
+		}
+	}
+	klog.V(4).Infof("Built PVC storage class map with %d entries", len(pvcMap))
+	return pvcMap, nil
+}
+
+// collectStorageFromVM extracts storage class IDs from a single VM.
+//
+// Strategy per dataVolumeTemplate:
+//  1. Explicit spec.storageClassName in the template -> use it directly.
+//  2. Look up the PVC by template name in the inventory -> use its resolved storageClassName.
+//  3. Explicit spec.storage.storageClassName in the template -> use it.
+func collectStorageFromVM(vm map[string]interface{}, vmNamespace string, storageIDSet map[string]bool, storageNameToID map[string]string, pvcSCMap map[string]string) {
+	dvtTemplates, err := query.GetValueByPathString(vm, "object.spec.dataVolumeTemplates")
+	if err != nil || dvtTemplates == nil {
+		return
+	}
+	dvtArray, ok := dvtTemplates.([]interface{})
+	if !ok {
+		return
+	}
+
+	vmName, _ := vm["name"].(string)
+	klog.V(4).Infof("VM %s has %d dataVolumeTemplates", vmName, len(dvtArray))
+
+	for _, dvtItem := range dvtArray {
+		dvtMap, ok := dvtItem.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		dvtName, _ := query.GetValueByPathString(dvtMap, "metadata.name")
+		dvtNameStr, _ := dvtName.(string)
+
+		// 1. Explicit storageClassName on the template spec.
+		if scVal, err := query.GetValueByPathString(dvtMap, "spec.storageClassName"); err == nil && scVal != nil {
+			if scName, ok := scVal.(string); ok && scName != "" {
+				klog.V(4).Infof("Found explicit storageClassName in template: %s", scName)
+				if id, exists := storageNameToID[scName]; exists {
+					storageIDSet[id] = true
+				}
+				continue
+			}
+		}
+
+		// 2. Look up the actual PVC in the inventory to get the resolved SC.
+		if pvcSCMap != nil && dvtNameStr != "" && vmNamespace != "" {
+			pvcKey := vmNamespace + "/" + dvtNameStr
+			if scName, exists := pvcSCMap[pvcKey]; exists {
+				klog.V(4).Infof("Resolved storageClassName from PVC %s: %s", pvcKey, scName)
+				if id, exists := storageNameToID[scName]; exists {
+					storageIDSet[id] = true
+				}
+				continue
+			}
+		}
+
+		// 3. Explicit storageClassName inside spec.storage.
+		if scVal, err := query.GetValueByPathString(dvtMap, "spec.storage.storageClassName"); err == nil && scVal != nil {
+			if scName, ok := scVal.(string); ok && scName != "" {
+				klog.V(4).Infof("Found storageClassName in spec.storage: %s", scName)
+				if id, exists := storageNameToID[scName]; exists {
+					storageIDSet[id] = true
+				}
+				continue
+			}
+		}
+
+		klog.V(2).Infof("WARNING: could not determine storageClassName for dataVolumeTemplate %q on VM %s", dvtNameStr, vmName)
+	}
 }
 
 // FetchTargetStorages extracts available destination storages from target provider

--- a/pkg/cmd/create/plan/storage/fetchers/openshift/fetcher_test.go
+++ b/pkg/cmd/create/plan/storage/fetchers/openshift/fetcher_test.go
@@ -120,6 +120,29 @@ func TestBuildTargetStorageList_Priority(t *testing.T) {
 	}
 }
 
+func TestBuildTargetStorageList_AnnotationKeysWithDots(t *testing.T) {
+	// Ensures that annotation keys containing dots (like storageclass.kubernetes.io/is-default-class)
+	// are correctly read when accessed through the inventory JSON structure.
+	// This test validates that buildTargetStorageList handles the same annotation keys
+	// that FetchSourceStorages uses to discover the default storage class.
+	storageArray := []interface{}{
+		scItem("non-default-sc", map[string]interface{}{
+			"storageclass.kubernetes.io/is-default-class": "false",
+		}),
+		scItem("default-sc", map[string]interface{}{
+			"storageclass.kubernetes.io/is-default-class": "true",
+		}),
+	}
+
+	result, err := buildTargetStorageList(storageArray)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result[0].StorageClass != "default-sc" {
+		t.Errorf("expected first SC 'default-sc', got '%s'", result[0].StorageClass)
+	}
+}
+
 func TestBuildTargetStorageList_NoDuplicateDefault(t *testing.T) {
 	storageArray := []interface{}{
 		scItem("default-sc", map[string]interface{}{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More accurate VM storage-source resolution that derives storage class from templates and PVC inventory instead of falling back to cluster defaults.
  * When no storage mappings exist, the plan now leaves storage maps empty rather than inserting a placeholder entry.

* **Tests**
  * Added coverage for identifying default storage classes using annotation keys that include dots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->