### PR TITLE
add-ca-auth-flag

### DIFF
--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -31,6 +31,7 @@ var (
 	kubeServer       string
 	kubeToken        string
 	insecureSkipTLS  bool
+	kubeCACert       string
 	maxResponseChars int
 	readOnly         bool
 )
@@ -58,8 +59,10 @@ Security:
   --key-file:    Path to TLS private key file (enables TLS when both cert and key provided)
 
 Kubernetes Authentication:
-  --server:  Kubernetes API server URL (passed to kubectl via --server flag)
-  --token:   Kubernetes authentication token (passed to kubectl via --token flag)
+  --server:                 Kubernetes API server URL (passed to kubectl via --server flag)
+  --token:                  Kubernetes authentication token (passed to kubectl via --token flag)
+  --certificate-authority:  Path to a CA certificate file for Kubernetes API TLS verification
+  --insecure-skip-tls-verify: Skip TLS certificate verification (insecure)
 
   These flags set default credentials for all requests. They work in both stdio and HTTP modes.
 
@@ -101,6 +104,7 @@ Manual Claude config: Add to claude_desktop_config.json:
 			util.SetDefaultKubeServer(kubeServer)
 			util.SetDefaultKubeToken(kubeToken)
 			util.SetDefaultInsecureSkipTLS(insecureSkipTLS)
+			util.SetDefaultKubeCACert(kubeCACert)
 
 			// Propagate verbosity from the inherited global --verbose flag
 			// so tool subprocesses produce matching debug output
@@ -236,6 +240,7 @@ Manual Claude config: Add to claude_desktop_config.json:
 	mcpCmd.Flags().StringVar(&kubeServer, "server", "", "Kubernetes API server URL (passed to kubectl via --server flag)")
 	mcpCmd.Flags().StringVar(&kubeToken, "token", "", "Kubernetes authentication token (passed to kubectl via --token flag)")
 	mcpCmd.Flags().BoolVar(&insecureSkipTLS, "insecure-skip-tls-verify", false, "Skip TLS certificate verification for Kubernetes API connections")
+	mcpCmd.Flags().StringVar(&kubeCACert, "certificate-authority", "", "Path to a CA certificate file for Kubernetes API TLS verification")
 	mcpCmd.Flags().IntVar(&maxResponseChars, "max-response-chars", 0, "Max characters for text output (0=unlimited). Helps small LLMs by truncating long responses")
 	mcpCmd.Flags().BoolVar(&readOnly, "read-only", false, "Run in read-only mode (disables write operations)")
 

--- a/pkg/mcp/util/util.go
+++ b/pkg/mcp/util/util.go
@@ -175,6 +175,10 @@ func GetDefaultKubeToken() string {
 // When true, --insecure-skip-tls-verify is prepended to every subprocess invocation.
 var defaultInsecureSkipTLS bool
 
+// defaultKubeCACert stores the path to a custom CA certificate file for Kubernetes API TLS.
+// When set, --certificate-authority is prepended to every subprocess invocation.
+var defaultKubeCACert string
+
 // defaultVerbosity stores the verbosity level set via the global --verbose flag.
 // When > 0, --verbose N is prepended to every subprocess invocation so that
 // tool-spawned commands inherit the same debug/trace level as the MCP server.
@@ -188,6 +192,16 @@ func SetDefaultInsecureSkipTLS(skip bool) {
 // GetDefaultInsecureSkipTLS returns whether TLS verification should be skipped.
 func GetDefaultInsecureSkipTLS() bool {
 	return defaultInsecureSkipTLS
+}
+
+// SetDefaultKubeCACert sets the default CA certificate path from CLI flags.
+func SetDefaultKubeCACert(path string) {
+	defaultKubeCACert = path
+}
+
+// GetDefaultKubeCACert returns the default CA certificate path set via CLI flags.
+func GetDefaultKubeCACert() string {
+	return defaultKubeCACert
 }
 
 // SetDefaultVerbosity sets the verbosity level from the global --verbose flag.
@@ -238,6 +252,12 @@ func RunKubectlMTVCommand(ctx context.Context, args []string) (string, error) {
 	// Prepend --insecure-skip-tls-verify when configured (before server/token)
 	if defaultInsecureSkipTLS {
 		args = append([]string{"--insecure-skip-tls-verify"}, args...)
+	}
+
+	// Prepend --certificate-authority when a custom CA cert path is configured
+	if defaultKubeCACert != "" {
+		klog.V(2).Infof("[auth] using --certificate-authority from CLI flag: %s", defaultKubeCACert)
+		args = append([]string{"--certificate-authority", defaultKubeCACert}, args...)
 	}
 
 	// Check context first (HTTP headers), then fall back to CLI defaults for --server flag

--- a/pkg/mcp/util/util_test.go
+++ b/pkg/mcp/util/util_test.go
@@ -657,6 +657,45 @@ func TestRunKubectlMTVCommand_NoCredsWhenNoneSet(t *testing.T) {
 	}
 }
 
+func TestRunKubectlMTVCommand_CACertFlagAppearsWhenSet(t *testing.T) {
+	origCACert := GetDefaultKubeCACert()
+	defer SetDefaultKubeCACert(origCACert)
+
+	SetDefaultKubeCACert("/tmp/custom-ca.crt")
+
+	ctx := WithShowCLI(context.Background(), true)
+
+	result, err := RunKubectlMTVCommand(ctx, []string{"get", "plan"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(result, "--certificate-authority") {
+		t.Errorf("expected --certificate-authority flag in command, got: %s", result)
+	}
+	if !strings.Contains(result, "/tmp/custom-ca.crt") {
+		t.Errorf("expected CA cert path in command, got: %s", result)
+	}
+}
+
+func TestRunKubectlMTVCommand_CACertFlagAbsentWhenNotSet(t *testing.T) {
+	origCACert := GetDefaultKubeCACert()
+	defer SetDefaultKubeCACert(origCACert)
+
+	SetDefaultKubeCACert("")
+
+	ctx := WithShowCLI(context.Background(), true)
+
+	result, err := RunKubectlMTVCommand(ctx, []string{"get", "plan"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if strings.Contains(result, "--certificate-authority") {
+		t.Errorf("--certificate-authority flag should NOT appear when no CA cert set, got: %s", result)
+	}
+}
+
 // --- Output format tests ---
 
 func TestOutputFormat(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--certificate-authority` CLI flag to configure the Kubernetes API certificate authority path for mcp-server.
  * Updated command help documentation to include the new certificate authority option and TLS verification settings alongside existing server and token configuration.

* **Tests**
  * Added unit tests verifying certificate authority flag injection in kubectl command generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->