### PR TITLE
add-mcp-read-only-hint

### DIFF
--- a/pkg/mcp/tools/mtv_help.go
+++ b/pkg/mcp/tools/mtv_help.go
@@ -37,6 +37,13 @@ Topics:
 
 Returns: command flags (with required/optional markers), usage pattern, and examples as structured data.`,
 		OutputSchema: mtvOutputSchema,
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "MTV Help",
+			ReadOnlyHint:    true,
+			IdempotentHint:  true,
+			DestructiveHint: ptrBool(false),
+			OpenWorldHint:   ptrBool(false),
+		},
 	}
 }
 

--- a/pkg/mcp/tools/mtv_read.go
+++ b/pkg/mcp/tools/mtv_read.go
@@ -21,6 +21,8 @@ type MTVReadInput struct {
 	Fields []string `json:"fields,omitempty" jsonschema:"Limit JSON to these top-level keys only (e.g. [name, id, concerns])"`
 }
 
+func ptrBool(b bool) *bool { return &b }
+
 // mtvOutputSchema is the shared output schema for mtv_read and mtv_write tools.
 // The "command" field is intentionally omitted to prevent small LLMs from
 // mimicking CLI command syntax (e.g., generating "kubectl-mtv get plan ...")
@@ -51,6 +53,12 @@ func GetMTVReadTool(registry *discovery.Registry) *mcp.Tool {
 		Name:         "mtv_read",
 		Description:  description,
 		OutputSchema: mtvOutputSchema,
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "MTV Read",
+			ReadOnlyHint:    true,
+			DestructiveHint: ptrBool(false),
+			OpenWorldHint:   ptrBool(false),
+		},
 	}
 }
 

--- a/pkg/mcp/tools/mtv_write.go
+++ b/pkg/mcp/tools/mtv_write.go
@@ -29,6 +29,11 @@ func GetMTVWriteTool(registry *discovery.Registry) *mcp.Tool {
 		Name:         "mtv_write",
 		Description:  description,
 		OutputSchema: mtvOutputSchema,
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "MTV Write",
+			DestructiveHint: ptrBool(true),
+			OpenWorldHint:   ptrBool(false),
+		},
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced tool metadata annotations with descriptive properties, including read-only status and destructive operation indicators for improved tool characterization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yaacov/kubectl-mtv/pull/231)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->