### PR TITLE
color-health-images

### DIFF
--- a/pkg/cmd/health/description.go
+++ b/pkg/cmd/health/description.go
@@ -84,7 +84,7 @@ func (r *HealthReport) buildControllerSection(b *describe.Builder) {
 	if len(ctrl.CustomImages) > 0 {
 		b.Field("Custom Images", fmt.Sprintf("%d overrides", len(ctrl.CustomImages)))
 		for _, img := range ctrl.CustomImages {
-			b.FieldC(img.Field, img.Image, output.Blue)
+			b.FieldC(img.Field, img.Image, output.ColorizeImage)
 		}
 	} else {
 		b.Field("Custom Images", "None")
@@ -137,7 +137,7 @@ func (r *HealthReport) buildPodsSection(b *describe.Builder) {
 				lines := strings.Split(pod.Image, "\n")
 				out := make([]string, len(lines))
 				for i, l := range lines {
-					out[i] = "  " + l
+					out[i] = "  " + output.ColorizeImage(l)
 				}
 				return out
 			}(),

--- a/pkg/util/output/style.go
+++ b/pkg/util/output/style.go
@@ -204,6 +204,18 @@ func ColorizeConcerns(val string) string {
 	return Green(val)
 }
 
+// ColorizeImage returns a colored image string based on its container registry.
+func ColorizeImage(image string) string {
+	switch {
+	case strings.HasPrefix(image, "quay.io/"):
+		return Cyan(image)
+	case strings.HasPrefix(image, "registry.redhat.io/"):
+		return Green(image)
+	default:
+		return Yellow(image)
+	}
+}
+
 // ColorizeProgress returns a colored string based on percentage thresholds.
 func ColorizeProgress(progress string) string {
 	trimmed := strings.TrimSpace(progress)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Container images in health command output are now color-coded by registry source for improved visual distinction: quay.io images appear in cyan, registry.redhat.io images in green, and other registries in yellow. This makes it easier to quickly identify image sources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yaacov/kubectl-mtv/pull/235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->