### PR TITLE
fix: apply offload defaults in auto-generated storage mapping path

### DIFF
--- a/pkg/cmd/create/mapping/offload/offload.go
+++ b/pkg/cmd/create/mapping/offload/offload.go
@@ -1,0 +1,190 @@
+// Package offload provides reusable helpers for creating and managing
+// offload-plugin Kubernetes Secrets.  The functions are decoupled from any
+// particular command-options struct so that both the "mapping" and "storage"
+// packages can share the same logic.
+package offload
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/yaacov/kubectl-mtv/pkg/util/client"
+)
+
+// SecretOptions holds the fields needed to build an offload Secret.
+type SecretOptions struct {
+	DefaultOffloadSecret string
+	VSphereUsername       string
+	VSpherePassword      string
+	VSphereURL           string
+	StorageUsername       string
+	StoragePassword      string
+	StorageEndpoint      string
+	CACert               string
+	InsecureSkipTLS      bool
+}
+
+// BuildSecret constructs the offload Secret object without persisting it.
+// For dry-run a deterministic Name is used; for live create GenerateName is used.
+func BuildSecret(namespace, baseName string, opts SecretOptions, dryRun bool) (*corev1.Secret, error) {
+	// Process CA certificate file if specified with @filename
+	cacert := opts.CACert
+	if strings.HasPrefix(cacert, "@") {
+		filePath := cacert[1:]
+		fileContent, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA certificate file %s: %v", filePath, err)
+		}
+		cacert = string(fileContent)
+	}
+
+	secretData := map[string][]byte{}
+
+	if opts.VSphereUsername != "" {
+		secretData["user"] = []byte(opts.VSphereUsername)
+	}
+	if opts.VSpherePassword != "" {
+		secretData["password"] = []byte(opts.VSpherePassword)
+	}
+	if opts.VSphereURL != "" {
+		secretData["url"] = []byte(opts.VSphereURL)
+	}
+	if opts.StorageUsername != "" {
+		secretData["storageUser"] = []byte(opts.StorageUsername)
+	}
+	if opts.StoragePassword != "" {
+		secretData["storagePassword"] = []byte(opts.StoragePassword)
+	}
+	if opts.StorageEndpoint != "" {
+		secretData["storageEndpoint"] = []byte(opts.StorageEndpoint)
+	}
+	if opts.InsecureSkipTLS {
+		secretData["insecureSkipVerify"] = []byte("true")
+	}
+	if cacert != "" {
+		secretData["cacert"] = []byte(cacert)
+	}
+
+	if len(secretData) == 0 {
+		return nil, fmt.Errorf("no offload secret fields provided")
+	}
+
+	meta := metav1.ObjectMeta{
+		Namespace: namespace,
+		Labels: map[string]string{
+			"createdForResourceType": "offload",
+			"createdForMapping":      baseName,
+		},
+	}
+	if dryRun {
+		meta.Name = fmt.Sprintf("%s-offload", baseName)
+	} else {
+		meta.GenerateName = fmt.Sprintf("%s-offload-", baseName)
+	}
+
+	return &corev1.Secret{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+		ObjectMeta: meta,
+		Data:       secretData,
+		Type:       corev1.SecretTypeOpaque,
+	}, nil
+}
+
+// CreateSecret creates an offload Secret on the cluster and returns it.
+func CreateSecret(configFlags *genericclioptions.ConfigFlags, namespace, baseName string, opts SecretOptions) (*corev1.Secret, error) {
+	k8sClient, err := client.GetKubernetesClientset(configFlags)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client: %v", err)
+	}
+
+	secret, err := BuildSecret(namespace, baseName, opts, false)
+	if err != nil {
+		return nil, err
+	}
+
+	return k8sClient.CoreV1().Secrets(namespace).Create(context.Background(), secret, metav1.CreateOptions{})
+}
+
+// ValidateSecretFields validates that when any offload-secret fields are
+// provided, all required fields are present.
+func ValidateSecretFields(opts SecretOptions) error {
+	hasInlineFields := opts.VSphereUsername != "" ||
+		opts.VSpherePassword != "" ||
+		opts.VSphereURL != "" ||
+		opts.StorageUsername != "" ||
+		opts.StoragePassword != "" ||
+		opts.StorageEndpoint != "" ||
+		opts.CACert != "" ||
+		opts.InsecureSkipTLS
+
+	// Conflict: user supplied both an existing secret name and inline credentials.
+	if opts.DefaultOffloadSecret != "" && hasInlineFields {
+		return fmt.Errorf("cannot specify both --default-offload-secret and inline offload credentials (--offload-vsphere-username, etc.); use one or the other")
+	}
+
+	if !hasInlineFields {
+		return nil // No validation needed if no fields provided
+	}
+
+	// If any offload fields are provided, validate required combinations
+	var missingFields []string
+
+	// vSphere credentials are required
+	if opts.VSphereUsername == "" {
+		missingFields = append(missingFields, "--offload-vsphere-username")
+	}
+	if opts.VSpherePassword == "" {
+		missingFields = append(missingFields, "--offload-vsphere-password")
+	}
+	if opts.VSphereURL == "" {
+		missingFields = append(missingFields, "--offload-vsphere-url")
+	}
+
+	// Storage credentials are required
+	if opts.StorageUsername == "" {
+		missingFields = append(missingFields, "--offload-storage-username")
+	}
+	if opts.StoragePassword == "" {
+		missingFields = append(missingFields, "--offload-storage-password")
+	}
+	if opts.StorageEndpoint == "" {
+		missingFields = append(missingFields, "--offload-storage-endpoint")
+	}
+
+	if len(missingFields) > 0 {
+		return fmt.Errorf("when creating offload secrets inline, all required fields must be provided. Missing: %s", strings.Join(missingFields, ", "))
+	}
+
+	return nil
+}
+
+// NeedsSecret returns true when the caller should create a new offload secret
+// (no existing secret name provided AND at least one credential field is set).
+func NeedsSecret(opts SecretOptions) bool {
+	return opts.DefaultOffloadSecret == "" &&
+		(opts.VSphereUsername != "" ||
+			opts.VSpherePassword != "" ||
+			opts.VSphereURL != "" ||
+			opts.StorageUsername != "" ||
+			opts.StoragePassword != "" ||
+			opts.StorageEndpoint != "" ||
+			opts.CACert != "" ||
+			opts.InsecureSkipTLS)
+}
+
+// CleanupSecret removes a previously created offload secret (typically on
+// rollback after a downstream failure).
+func CleanupSecret(configFlags *genericclioptions.ConfigFlags, namespace, secretName string) error {
+	k8sClient, err := client.GetKubernetesClientset(configFlags)
+	if err != nil {
+		return fmt.Errorf("failed to get kubernetes client: %v", err)
+	}
+
+	return k8sClient.CoreV1().Secrets(namespace).Delete(context.Background(), secretName, metav1.DeleteOptions{})
+}

--- a/pkg/cmd/create/mapping/offload_secrets.go
+++ b/pkg/cmd/create/mapping/offload_secrets.go
@@ -1,159 +1,45 @@
 package mapping
 
 import (
-	"context"
-	"fmt"
-	"os"
-	"strings"
-
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/yaacov/kubectl-mtv/pkg/util/client"
+	"github.com/yaacov/kubectl-mtv/pkg/cmd/create/mapping/offload"
 )
+
+// toSecretOptions converts the offload-related fields of StorageCreateOptions
+// into the shared offload.SecretOptions.
+func toSecretOptions(opts StorageCreateOptions) offload.SecretOptions {
+	return offload.SecretOptions{
+		DefaultOffloadSecret: opts.DefaultOffloadSecret,
+		VSphereUsername:      opts.OffloadVSphereUsername,
+		VSpherePassword:      opts.OffloadVSpherePassword,
+		VSphereURL:           opts.OffloadVSphereURL,
+		StorageUsername:      opts.OffloadStorageUsername,
+		StoragePassword:      opts.OffloadStoragePassword,
+		StorageEndpoint:      opts.OffloadStorageEndpoint,
+		CACert:               opts.OffloadCACert,
+		InsecureSkipTLS:      opts.OffloadInsecureSkipTLS,
+	}
+}
 
 // buildOffloadSecret constructs the offload Secret object without persisting it.
 // For dry-run a deterministic Name is used; for live create GenerateName is used.
 func buildOffloadSecret(namespace, baseName string, opts StorageCreateOptions, dryRun bool) (*corev1.Secret, error) {
-	// Process CA certificate file if specified with @filename
-	cacert := opts.OffloadCACert
-	if strings.HasPrefix(cacert, "@") {
-		filePath := cacert[1:]
-		fileContent, err := os.ReadFile(filePath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read CA certificate file %s: %v", filePath, err)
-		}
-		cacert = string(fileContent)
-	}
-
-	secretData := map[string][]byte{}
-
-	if opts.OffloadVSphereUsername != "" {
-		secretData["user"] = []byte(opts.OffloadVSphereUsername)
-	}
-	if opts.OffloadVSpherePassword != "" {
-		secretData["password"] = []byte(opts.OffloadVSpherePassword)
-	}
-	if opts.OffloadVSphereURL != "" {
-		secretData["url"] = []byte(opts.OffloadVSphereURL)
-	}
-	if opts.OffloadStorageUsername != "" {
-		secretData["storageUser"] = []byte(opts.OffloadStorageUsername)
-	}
-	if opts.OffloadStoragePassword != "" {
-		secretData["storagePassword"] = []byte(opts.OffloadStoragePassword)
-	}
-	if opts.OffloadStorageEndpoint != "" {
-		secretData["storageEndpoint"] = []byte(opts.OffloadStorageEndpoint)
-	}
-	if opts.OffloadInsecureSkipTLS {
-		secretData["insecureSkipVerify"] = []byte("true")
-	}
-	if cacert != "" {
-		secretData["cacert"] = []byte(cacert)
-	}
-
-	if len(secretData) == 0 {
-		return nil, fmt.Errorf("no offload secret fields provided")
-	}
-
-	meta := metav1.ObjectMeta{
-		Namespace: namespace,
-		Labels: map[string]string{
-			"createdForResourceType": "offload",
-			"createdForMapping":      baseName,
-		},
-	}
-	if dryRun {
-		meta.Name = fmt.Sprintf("%s-offload", baseName)
-	} else {
-		meta.GenerateName = fmt.Sprintf("%s-offload-", baseName)
-	}
-
-	return &corev1.Secret{
-		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
-		ObjectMeta: meta,
-		Data:       secretData,
-		Type:       corev1.SecretTypeOpaque,
-	}, nil
+	return offload.BuildSecret(namespace, baseName, toSecretOptions(opts), dryRun)
 }
 
 // createOffloadSecret creates a secret for offload plugin authentication
 func createOffloadSecret(configFlags *genericclioptions.ConfigFlags, namespace, baseName string, opts StorageCreateOptions) (*corev1.Secret, error) {
-	k8sClient, err := client.GetKubernetesClientset(configFlags)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create kubernetes client: %v", err)
-	}
-
-	secret, err := buildOffloadSecret(namespace, baseName, opts, false)
-	if err != nil {
-		return nil, err
-	}
-
-	return k8sClient.CoreV1().Secrets(namespace).Create(context.Background(), secret, metav1.CreateOptions{})
+	return offload.CreateSecret(configFlags, namespace, baseName, toSecretOptions(opts))
 }
 
 // validateOffloadSecretFields validates that required fields are present for offload secret creation
 func validateOffloadSecretFields(opts StorageCreateOptions) error {
-	// Check if any offload secret creation fields are provided
-	hasOffloadFields := opts.OffloadVSphereUsername != "" ||
-		opts.OffloadVSpherePassword != "" ||
-		opts.OffloadVSphereURL != "" ||
-		opts.OffloadStorageUsername != "" ||
-		opts.OffloadStoragePassword != "" ||
-		opts.OffloadStorageEndpoint != "" ||
-		opts.OffloadCACert != "" ||
-		opts.OffloadInsecureSkipTLS
-
-	if !hasOffloadFields {
-		return nil // No validation needed if no fields provided
-	}
-
-	// If any offload fields are provided, validate required combinations
-	var missingFields []string
-
-	// vSphere credentials are required
-	if opts.OffloadVSphereUsername == "" {
-		missingFields = append(missingFields, "--offload-vsphere-username")
-	}
-	if opts.OffloadVSpherePassword == "" {
-		missingFields = append(missingFields, "--offload-vsphere-password")
-	}
-	if opts.OffloadVSphereURL == "" {
-		missingFields = append(missingFields, "--offload-vsphere-url")
-	}
-
-	// Storage credentials are required
-	if opts.OffloadStorageUsername == "" {
-		missingFields = append(missingFields, "--offload-storage-username")
-	}
-	if opts.OffloadStoragePassword == "" {
-		missingFields = append(missingFields, "--offload-storage-password")
-	}
-	if opts.OffloadStorageEndpoint == "" {
-		missingFields = append(missingFields, "--offload-storage-endpoint")
-	}
-
-	if len(missingFields) > 0 {
-		return fmt.Errorf("when creating offload secrets inline, all required fields must be provided. Missing: %s", strings.Join(missingFields, ", "))
-	}
-
-	return nil
+	return offload.ValidateSecretFields(toSecretOptions(opts))
 }
 
 // needsOffloadSecret determines if we should create an offload secret
 func needsOffloadSecret(opts StorageCreateOptions) bool {
-	// Only create a secret if:
-	// 1. No existing secret name is provided AND
-	// 2. Some offload secret creation fields are provided
-	return opts.DefaultOffloadSecret == "" &&
-		(opts.OffloadVSphereUsername != "" ||
-			opts.OffloadVSpherePassword != "" ||
-			opts.OffloadVSphereURL != "" ||
-			opts.OffloadStorageUsername != "" ||
-			opts.OffloadStoragePassword != "" ||
-			opts.OffloadStorageEndpoint != "" ||
-			opts.OffloadCACert != "" ||
-			opts.OffloadInsecureSkipTLS)
+	return offload.NeedsSecret(toSecretOptions(opts))
 }

--- a/pkg/cmd/create/mapping/storage.go
+++ b/pkg/cmd/create/mapping/storage.go
@@ -14,6 +14,7 @@ import (
 
 	forkliftv1beta1 "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/provider"
+	"github.com/yaacov/kubectl-mtv/pkg/cmd/create/mapping/offload"
 	"github.com/yaacov/kubectl-mtv/pkg/util/client"
 	"github.com/yaacov/kubectl-mtv/pkg/util/output"
 )
@@ -354,10 +355,5 @@ func createStorageMappingWithOptionsAndSecret(ctx context.Context, opts StorageC
 
 // cleanupOffloadSecret removes a created offload secret on failure
 func cleanupOffloadSecret(configFlags *genericclioptions.ConfigFlags, namespace, secretName string) error {
-	k8sClient, err := client.GetKubernetesClientset(configFlags)
-	if err != nil {
-		return fmt.Errorf("failed to get kubernetes client: %v", err)
-	}
-
-	return k8sClient.CoreV1().Secrets(namespace).Delete(context.Background(), secretName, metav1.DeleteOptions{})
+	return offload.CleanupSecret(configFlags, namespace, secretName)
 }

--- a/pkg/cmd/create/plan/plan.go
+++ b/pkg/cmd/create/plan/plan.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/provider"
 	mapping "github.com/yaacov/kubectl-mtv/pkg/cmd/create/mapping"
+	"github.com/yaacov/kubectl-mtv/pkg/cmd/create/mapping/offload"
 	"github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/network"
 	"github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/storage"
 	"github.com/yaacov/kubectl-mtv/pkg/cmd/create/provider/defaultprovider"
@@ -128,6 +129,7 @@ func Create(ctx context.Context, opts CreatePlanOptions) error {
 	// Track which maps we create for cleanup if needed
 	createdNetworkMap := false
 	createdStorageMap := false
+	var createdOffloadSecretName string
 
 	// Extract VM names from the plan
 	var planVMNames []string
@@ -250,7 +252,8 @@ func Create(ctx context.Context, opts CreatePlanOptions) error {
 			}
 		} else {
 			// Create default storage mapping using existing logic
-			storageMapName, err := storage.CreateStorageMap(ctx, storage.StorageMapperOptions{
+			var storageMapName string
+			storageMapName, createdOffloadSecretName, err = storage.CreateStorageMap(ctx, storage.StorageMapperOptions{
 				Name:                      opts.Name,
 				Namespace:                 opts.Namespace,
 				SourceProvider:            opts.SourceProvider,
@@ -264,6 +267,19 @@ func Create(ctx context.Context, opts CreatePlanOptions) error {
 				DefaultTargetStorageClass: opts.DefaultTargetStorageClass,
 				DryRun:                    opts.DryRun,
 				OutputFormat:              opts.OutputFormat,
+				DefaultVolumeMode:         opts.DefaultVolumeMode,
+				DefaultAccessMode:         opts.DefaultAccessMode,
+				DefaultOffloadPlugin:      opts.DefaultOffloadPlugin,
+				DefaultOffloadSecret:      opts.DefaultOffloadSecret,
+				DefaultOffloadVendor:      opts.DefaultOffloadVendor,
+				OffloadVSphereUsername:    opts.OffloadVSphereUsername,
+				OffloadVSpherePassword:    opts.OffloadVSpherePassword,
+				OffloadVSphereURL:         opts.OffloadVSphereURL,
+				OffloadStorageUsername:    opts.OffloadStorageUsername,
+				OffloadStoragePassword:    opts.OffloadStoragePassword,
+				OffloadStorageEndpoint:    opts.OffloadStorageEndpoint,
+				OffloadCACert:             opts.OffloadCACert,
+				OffloadInsecureSkipTLS:    opts.OffloadInsecureSkipTLS,
 			})
 			if err != nil {
 				// Clean up the network map if we created it
@@ -346,6 +362,11 @@ func Create(ctx context.Context, opts CreatePlanOptions) error {
 				fmt.Printf("Warning: failed to delete storage map: %v\n", delErr)
 			}
 		}
+		if createdOffloadSecretName != "" {
+			if delErr := offload.CleanupSecret(opts.ConfigFlags, opts.Namespace, createdOffloadSecretName); delErr != nil {
+				fmt.Printf("Warning: failed to clean up offload secret '%s': %v\n", createdOffloadSecretName, delErr)
+			}
+		}
 		return fmt.Errorf("failed to convert Plan to Unstructured: %v", err)
 	}
 	planUnstructured := &unstructured.Unstructured{Object: unstructuredPlan}
@@ -362,6 +383,11 @@ func Create(ctx context.Context, opts CreatePlanOptions) error {
 		if createdStorageMap {
 			if delErr := deleteMap(opts.ConfigFlags, client.StorageMapGVR, opts.StorageMapping, opts.Namespace); delErr != nil {
 				fmt.Printf("Warning: failed to delete storage map: %v\n", delErr)
+			}
+		}
+		if createdOffloadSecretName != "" {
+			if delErr := offload.CleanupSecret(opts.ConfigFlags, opts.Namespace, createdOffloadSecretName); delErr != nil {
+				fmt.Printf("Warning: failed to clean up offload secret '%s': %v\n", createdOffloadSecretName, delErr)
 			}
 		}
 		return fmt.Errorf("failed to create plan: %v", err)

--- a/pkg/cmd/create/plan/storage/factory.go
+++ b/pkg/cmd/create/plan/storage/factory.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/provider"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
 
+	"github.com/yaacov/kubectl-mtv/pkg/cmd/create/mapping/offload"
 	"github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/storage/fetchers"
 	ec2Fetcher "github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/storage/fetchers/ec2"
 	hypervFetcher "github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/storage/fetchers/hyperv"
@@ -63,10 +64,30 @@ type StorageMapperOptions struct {
 	DefaultTargetStorageClass string
 	DryRun                    bool
 	OutputFormat              string
+
+	// Storage enhancement options
+	DefaultVolumeMode    string
+	DefaultAccessMode    string
+	DefaultOffloadPlugin string
+	DefaultOffloadSecret string
+	DefaultOffloadVendor string
+
+	// Offload secret creation fields
+	OffloadVSphereUsername string
+	OffloadVSpherePassword string
+	OffloadVSphereURL      string
+	OffloadStorageUsername  string
+	OffloadStoragePassword string
+	OffloadStorageEndpoint string
+	OffloadCACert          string
+	OffloadInsecureSkipTLS bool
 }
 
-// CreateStorageMap creates a storage map using the new fetcher-based architecture
-func CreateStorageMap(ctx context.Context, opts StorageMapperOptions) (string, error) {
+// CreateStorageMap creates a storage map using the new fetcher-based architecture.
+// It returns the storage map name, the name of any offload secret that was created
+// (empty if none), and an error. The caller is responsible for cleaning up the
+// returned secret if later operations fail.
+func CreateStorageMap(ctx context.Context, opts StorageMapperOptions) (storageMapName string, createdSecretName string, err error) {
 	klog.V(4).Infof("DEBUG: Creating storage map - Source: %s, Target: %s, DefaultTargetStorageClass: '%s'",
 		opts.SourceProvider, opts.TargetProvider, opts.DefaultTargetStorageClass)
 
@@ -74,7 +95,7 @@ func CreateStorageMap(ctx context.Context, opts StorageMapperOptions) (string, e
 	sourceProviderNamespace := client.GetProviderNamespace(opts.SourceProviderNamespace, opts.Namespace)
 	sourceFetcher, err := GetSourceStorageFetcher(ctx, opts.ConfigFlags, opts.SourceProvider, sourceProviderNamespace, opts.InventoryInsecureSkipTLS)
 	if err != nil {
-		return "", fmt.Errorf("failed to get source storage fetcher: %v", err)
+		return "", "", fmt.Errorf("failed to get source storage fetcher: %v", err)
 	}
 	klog.V(4).Infof("DEBUG: Source storage fetcher created for provider: %s", opts.SourceProvider)
 
@@ -82,14 +103,14 @@ func CreateStorageMap(ctx context.Context, opts StorageMapperOptions) (string, e
 	targetProviderNamespace := client.GetProviderNamespace(opts.TargetProviderNamespace, opts.Namespace)
 	targetFetcher, err := GetTargetStorageFetcher(ctx, opts.ConfigFlags, opts.TargetProvider, targetProviderNamespace, opts.InventoryInsecureSkipTLS)
 	if err != nil {
-		return "", fmt.Errorf("failed to get target storage fetcher: %v", err)
+		return "", "", fmt.Errorf("failed to get target storage fetcher: %v", err)
 	}
 	klog.V(4).Infof("DEBUG: Target storage fetcher created for provider: %s", opts.TargetProvider)
 
 	// Fetch source storages
 	sourceStorages, err := sourceFetcher.FetchSourceStorages(ctx, opts.ConfigFlags, opts.SourceProvider, sourceProviderNamespace, opts.InventoryURL, opts.PlanVMNames, opts.InventoryInsecureSkipTLS)
 	if err != nil {
-		return "", fmt.Errorf("failed to fetch source storages: %v", err)
+		return "", "", fmt.Errorf("failed to fetch source storages: %v", err)
 	}
 	klog.V(4).Infof("DEBUG: Fetched %d source storages", len(sourceStorages))
 
@@ -99,7 +120,7 @@ func CreateStorageMap(ctx context.Context, opts StorageMapperOptions) (string, e
 		klog.V(4).Infof("DEBUG: Fetching target storages from target provider: %s", opts.TargetProvider)
 		targetStorages, err = targetFetcher.FetchTargetStorages(ctx, opts.ConfigFlags, opts.TargetProvider, targetProviderNamespace, opts.InventoryURL, opts.InventoryInsecureSkipTLS)
 		if err != nil {
-			return "", fmt.Errorf("failed to fetch target storages: %v", err)
+			return "", "", fmt.Errorf("failed to fetch target storages: %v", err)
 		}
 		klog.V(4).Infof("DEBUG: Fetched %d target storages", len(targetStorages))
 	} else {
@@ -109,7 +130,46 @@ func CreateStorageMap(ctx context.Context, opts StorageMapperOptions) (string, e
 	// Get provider-specific storage mapper
 	storageMapper, sourceProviderType, targetProviderType, err := GetStorageMapper(ctx, opts.ConfigFlags, opts.SourceProvider, sourceProviderNamespace, opts.TargetProvider, targetProviderNamespace, opts.InventoryInsecureSkipTLS)
 	if err != nil {
-		return "", fmt.Errorf("failed to get storage mapper: %v", err)
+		return "", "", fmt.Errorf("failed to get storage mapper: %v", err)
+	}
+
+	// Handle offload secret creation
+	secretOpts := offload.SecretOptions{
+		DefaultOffloadSecret: opts.DefaultOffloadSecret,
+		VSphereUsername:      opts.OffloadVSphereUsername,
+		VSpherePassword:     opts.OffloadVSpherePassword,
+		VSphereURL:          opts.OffloadVSphereURL,
+		StorageUsername:      opts.OffloadStorageUsername,
+		StoragePassword:     opts.OffloadStoragePassword,
+		StorageEndpoint:     opts.OffloadStorageEndpoint,
+		CACert:              opts.OffloadCACert,
+		InsecureSkipTLS:     opts.OffloadInsecureSkipTLS,
+	}
+
+	if err := offload.ValidateSecretFields(secretOpts); err != nil {
+		return "", "", err
+	}
+
+	storageMapName = opts.Name + "-storage-map"
+	if opts.DryRun && offload.NeedsSecret(secretOpts) {
+		sec, err := offload.BuildSecret(opts.Namespace, storageMapName, secretOpts, true)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to build offload secret for dry-run: %v", err)
+		}
+		if err := output.OutputResource(sec, opts.OutputFormat); err != nil {
+			return "", "", err
+		}
+		opts.DefaultOffloadSecret = sec.Name
+	} else if !opts.DryRun && offload.NeedsSecret(secretOpts) {
+		fmt.Printf("Creating offload secret for storage mapping '%s'\n", storageMapName)
+
+		createdSecret, err := offload.CreateSecret(opts.ConfigFlags, opts.Namespace, storageMapName, secretOpts)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to create offload secret: %v", err)
+		}
+		opts.DefaultOffloadSecret = createdSecret.Name
+		createdSecretName = createdSecret.Name
+		fmt.Printf("Created offload secret '%s' for storage mapping authentication\n", createdSecret.Name)
 	}
 
 	// Create storage pairs using provider-specific mapping logic
@@ -117,25 +177,44 @@ func CreateStorageMap(ctx context.Context, opts StorageMapperOptions) (string, e
 		DefaultTargetStorageClass: opts.DefaultTargetStorageClass,
 		SourceProviderType:        sourceProviderType,
 		TargetProviderType:        targetProviderType,
+		DefaultVolumeMode:         opts.DefaultVolumeMode,
+		DefaultAccessMode:         opts.DefaultAccessMode,
+		DefaultOffloadPlugin:      opts.DefaultOffloadPlugin,
+		DefaultOffloadSecret:      opts.DefaultOffloadSecret,
+		DefaultOffloadVendor:      opts.DefaultOffloadVendor,
 	}
 	storagePairs, err := storageMapper.CreateStoragePairs(sourceStorages, targetStorages, mappingOpts)
 	if err != nil {
-		return "", fmt.Errorf("failed to create storage pairs: %v", err)
+		if createdSecretName != "" {
+			if delErr := offload.CleanupSecret(opts.ConfigFlags, opts.Namespace, createdSecretName); delErr != nil {
+				fmt.Printf("Warning: failed to clean up offload secret '%s': %v\n", createdSecretName, delErr)
+			}
+		}
+		return "", "", fmt.Errorf("failed to create storage pairs: %v", err)
 	}
 
 	if opts.DryRun {
-		storageMap, storageMapName, err := buildStorageMapObject(opts, storagePairs)
+		storageMap, dryRunMapName, err := buildStorageMapObject(opts, storagePairs)
 		if err != nil {
-			return "", err
+			return "", "", err
 		}
 		if err := output.OutputResource(storageMap, opts.OutputFormat); err != nil {
-			return "", err
+			return "", "", err
 		}
-		return storageMapName, nil
+		return dryRunMapName, "", nil
 	}
 
 	// Create the storage map using the existing infrastructure
-	return createStorageMap(opts, storagePairs)
+	storageMapResult, err := createStorageMap(opts, storagePairs)
+	if err != nil {
+		if createdSecretName != "" {
+			if delErr := offload.CleanupSecret(opts.ConfigFlags, opts.Namespace, createdSecretName); delErr != nil {
+				fmt.Printf("Warning: failed to clean up offload secret '%s': %v\n", createdSecretName, delErr)
+			}
+		}
+		return "", "", err
+	}
+	return storageMapResult, createdSecretName, nil
 }
 
 // buildStorageMapObject builds a typed StorageMap (no API call).

--- a/pkg/cmd/create/plan/storage/mapper/ec2/mapper.go
+++ b/pkg/cmd/create/plan/storage/mapper/ec2/mapper.go
@@ -140,6 +140,9 @@ func (m *EC2StorageMapper) CreateStoragePairs(sourceStorages []ref.Ref, targetSt
 			})
 		}
 		klog.V(4).Infof("DEBUG: EC2 storage mapper - Created %d storage pairs (user default)", len(storagePairs))
+
+		storagePairs = mapper.ApplyOffloadToPairs(storagePairs, opts)
+
 		return storagePairs, nil
 	}
 
@@ -179,5 +182,8 @@ func (m *EC2StorageMapper) CreateStoragePairs(sourceStorages []ref.Ref, targetSt
 	}
 
 	klog.V(4).Infof("DEBUG: EC2 storage mapper - Created %d storage pairs", len(storagePairs))
+
+	storagePairs = mapper.ApplyOffloadToPairs(storagePairs, opts)
+
 	return storagePairs, nil
 }

--- a/pkg/cmd/create/plan/storage/mapper/hyperv/mapper.go
+++ b/pkg/cmd/create/plan/storage/mapper/hyperv/mapper.go
@@ -41,6 +41,9 @@ func (m *HyperVStorageMapper) CreateStoragePairs(sourceStorages []ref.Ref, targe
 	}
 
 	klog.V(4).Infof("DEBUG: Created %d storage pairs", len(storagePairs))
+
+	storagePairs = mapper.ApplyOffloadToPairs(storagePairs, opts)
+
 	return storagePairs, nil
 }
 

--- a/pkg/cmd/create/plan/storage/mapper/interfaces.go
+++ b/pkg/cmd/create/plan/storage/mapper/interfaces.go
@@ -3,6 +3,7 @@ package mapper
 import (
 	forkliftv1beta1 "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // StorageMappingOptions contains options for storage mapping
@@ -10,9 +11,42 @@ type StorageMappingOptions struct {
 	DefaultTargetStorageClass string
 	SourceProviderType        string
 	TargetProviderType        string
+	DefaultVolumeMode         string
+	DefaultAccessMode         string
+	DefaultOffloadPlugin      string
+	DefaultOffloadSecret      string
+	DefaultOffloadVendor      string
 }
 
 // StorageMapper defines the interface for storage mapping operations
 type StorageMapper interface {
 	CreateStoragePairs(sourceStorages []ref.Ref, targetStorages []forkliftv1beta1.DestinationStorage, opts StorageMappingOptions) ([]forkliftv1beta1.StoragePair, error)
+}
+
+// ApplyOffloadToPairs applies default volume mode, access mode, and offload
+// plugin settings from opts to every pair that does not already have them set.
+func ApplyOffloadToPairs(pairs []forkliftv1beta1.StoragePair, opts StorageMappingOptions) []forkliftv1beta1.StoragePair {
+	for i := range pairs {
+		if opts.DefaultVolumeMode != "" && pairs[i].Destination.VolumeMode == "" {
+			pairs[i].Destination.VolumeMode = corev1.PersistentVolumeMode(opts.DefaultVolumeMode)
+		}
+
+		if opts.DefaultAccessMode != "" && pairs[i].Destination.AccessMode == "" {
+			pairs[i].Destination.AccessMode = corev1.PersistentVolumeAccessMode(opts.DefaultAccessMode)
+		}
+
+		if opts.DefaultOffloadPlugin != "" && opts.DefaultOffloadVendor != "" && pairs[i].OffloadPlugin == nil {
+			switch opts.DefaultOffloadPlugin {
+			case "vsphere":
+				pairs[i].OffloadPlugin = &forkliftv1beta1.OffloadPlugin{
+					VSphereXcopyPluginConfig: &forkliftv1beta1.VSphereXcopyPluginConfig{
+						SecretRef:            opts.DefaultOffloadSecret,
+						StorageVendorProduct: forkliftv1beta1.StorageVendorProduct(opts.DefaultOffloadVendor),
+					},
+				}
+			}
+		}
+	}
+
+	return pairs
 }

--- a/pkg/cmd/create/plan/storage/mapper/openshift/mapper.go
+++ b/pkg/cmd/create/plan/storage/mapper/openshift/mapper.go
@@ -36,7 +36,12 @@ func (m *OpenShiftStorageMapper) CreateStoragePairs(sourceStorages []ref.Ref, ta
 
 	// (a) User specified a default SC — map every source to it.
 	if opts.DefaultTargetStorageClass != "" {
-		return createDefaultStoragePairs(sourceStorages, opts.DefaultTargetStorageClass)
+		pairs, err := createDefaultStoragePairs(sourceStorages, opts.DefaultTargetStorageClass)
+		if err != nil {
+			return nil, err
+		}
+		pairs = mapper.ApplyOffloadToPairs(pairs, opts)
+		return pairs, nil
 	}
 
 	// Resolve the default SC for gap-filling (best SC selected by the target fetcher).
@@ -45,11 +50,21 @@ func (m *OpenShiftStorageMapper) CreateStoragePairs(sourceStorages []ref.Ref, ta
 	// (b) + (c) For OCP-to-OCP: same-name matching with gap-fill.
 	if opts.TargetProviderType == "openshift" {
 		klog.V(4).Infof("DEBUG: OCP-to-OCP migration detected, attempting same-name matching with gap-fill")
-		return createSameNameWithFallback(sourceStorages, targetStorages, defaultSC)
+		pairs, err := createSameNameWithFallback(sourceStorages, targetStorages, defaultSC)
+		if err != nil {
+			return nil, err
+		}
+		pairs = mapper.ApplyOffloadToPairs(pairs, opts)
+		return pairs, nil
 	}
 
 	// Non-OCP target: map all sources to the default SC.
-	return createAllToDefaultPairs(sourceStorages, defaultSC)
+	pairs, err := createAllToDefaultPairs(sourceStorages, defaultSC)
+	if err != nil {
+		return nil, err
+	}
+	pairs = mapper.ApplyOffloadToPairs(pairs, opts)
+	return pairs, nil
 }
 
 // createDefaultStoragePairs maps every source to the user-specified SC.

--- a/pkg/cmd/create/plan/storage/mapper/openstack/mapper.go
+++ b/pkg/cmd/create/plan/storage/mapper/openstack/mapper.go
@@ -41,6 +41,9 @@ func (m *OpenStackStorageMapper) CreateStoragePairs(sourceStorages []ref.Ref, ta
 	}
 
 	klog.V(4).Infof("DEBUG: Created %d storage pairs", len(storagePairs))
+
+	storagePairs = mapper.ApplyOffloadToPairs(storagePairs, opts)
+
 	return storagePairs, nil
 }
 

--- a/pkg/cmd/create/plan/storage/mapper/ova/mapper.go
+++ b/pkg/cmd/create/plan/storage/mapper/ova/mapper.go
@@ -41,6 +41,9 @@ func (m *OVAStorageMapper) CreateStoragePairs(sourceStorages []ref.Ref, targetSt
 	}
 
 	klog.V(4).Infof("DEBUG: Created %d storage pairs", len(storagePairs))
+
+	storagePairs = mapper.ApplyOffloadToPairs(storagePairs, opts)
+
 	return storagePairs, nil
 }
 

--- a/pkg/cmd/create/plan/storage/mapper/ovirt/mapper.go
+++ b/pkg/cmd/create/plan/storage/mapper/ovirt/mapper.go
@@ -41,6 +41,9 @@ func (m *OvirtStorageMapper) CreateStoragePairs(sourceStorages []ref.Ref, target
 	}
 
 	klog.V(4).Infof("DEBUG: Created %d storage pairs", len(storagePairs))
+
+	storagePairs = mapper.ApplyOffloadToPairs(storagePairs, opts)
+
 	return storagePairs, nil
 }
 

--- a/pkg/cmd/create/plan/storage/mapper/vsphere/mapper.go
+++ b/pkg/cmd/create/plan/storage/mapper/vsphere/mapper.go
@@ -41,6 +41,9 @@ func (m *VSphereStorageMapper) CreateStoragePairs(sourceStorages []ref.Ref, targ
 	}
 
 	klog.V(4).Infof("DEBUG: Created %d storage pairs", len(storagePairs))
+
+	storagePairs = mapper.ApplyOffloadToPairs(storagePairs, opts)
+
 	return storagePairs, nil
 }
 


### PR DESCRIPTION
## Summary

- Fix `--default-offload-plugin`, `--default-offload-secret`, `--default-offload-vendor`, `--default-volume-mode`, and `--default-access-mode` flags being silently ignored when `--storage-pairs` is not provided
- Extract offload secret logic into shared `mapping/offload` package for reuse by both code paths
- Add `ApplyOffloadToPairs` helper to apply offload/volume/access defaults to all provider mappers

## Problem

When running `create plan` without `--storage-pairs`, the auto-generated storage mapping path (`storage.CreateStorageMap`) never passed offload configuration through to the storage pairs. Only the explicit `--storage-pairs` path handled these flags.

For example, this command silently ignored the offload flags:
```
kubectl-mtv create plan --name my-plan -S my-vsphere --vms "my-vm" \
  --default-offload-plugin vsphere \
  --default-offload-secret my-secret \
  --default-offload-vendor ontap \
  --default-target-storage-class my-storage-class
```

## Root Cause

`StorageMapperOptions` and `StorageMappingOptions` lacked offload fields, and `plan.go` never passed them to the auto-generated path.

## Changes

- **New:** `pkg/cmd/create/mapping/offload/` — shared package for offload secret creation, validation, and cleanup
- **Modified:** `offload_secrets.go` — delegates to shared package
- **Modified:** `factory.go` — extended `StorageMapperOptions`, added secret creation/cleanup in `CreateStorageMap`
- **Modified:** `interfaces.go` — extended `StorageMappingOptions`, added `ApplyOffloadToPairs` helper
- **Modified:** `plan.go` — passes offload fields to `StorageMapperOptions`, cleans up offload secret on rollback
- **Modified:** All 7 provider mappers — call `ApplyOffloadToPairs` before returning pairs

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/cmd/create/plan/storage/...` passes
- [x] `go test ./pkg/cmd/create/mapping/...` passes
- [x] Dry-run verified: offload config appears in StorageMap YAML
- [x] Live test: plan created successfully with offload defaults applied to StorageMap
- [x] Conflict validation: error when both `--default-offload-secret` and inline credentials provided