### PR TITLE
feat: support multiple --setting/--value pairs in settings set

### DIFF
--- a/cmd/settings/set.go
+++ b/cmd/settings/set.go
@@ -15,16 +15,19 @@ import (
 
 // NewSetCmd creates the 'settings set' subcommand.
 func NewSetCmd(kubeConfigFlags *genericclioptions.ConfigFlags, globalConfig GlobalConfigGetter) *cobra.Command {
-	var settingName string
-	var settingValue string
+	var settingNames []string
+	var settingValues []string
 
 	cmd := &cobra.Command{
 		Use:   "set",
-		Short: "Set a ForkliftController setting value",
-		Long: `Set a ForkliftController setting value.
+		Short: "Set one or more ForkliftController setting values",
+		Long: `Set one or more ForkliftController setting values.
 
 The setting name must be one of the supported settings. Use 'kubectl mtv settings'
 to see all available settings and their current values.
+
+Multiple --setting/--value pairs can be specified to update several settings in a
+single Kubernetes patch operation, avoiding multiple reconciliation cycles.
 
 Value types are automatically validated:
   - Boolean settings accept: true, false, yes, no, 1, 0
@@ -44,38 +47,45 @@ Examples:
   # Increase virt-v2v memory limit for large VMs
   kubectl mtv settings set --setting virt_v2v_container_limits_memory --value 16Gi
 
+  # Set multiple settings at once (single reconciliation cycle)
+  kubectl mtv settings set --setting feature_mcp_server --value true \
+                           --setting mcp_server_lightspeed_set_mcp_gate --value true
+
   # Set a value starting with -- (use -- to stop flag parsing)
   kubectl mtv settings set --setting virt_v2v_extra_args --value --machine-readable`,
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(settingNames) != len(settingValues) {
+				return fmt.Errorf("number of --setting flags (%d) must match number of --value flags (%d)", len(settingNames), len(settingValues))
+			}
+
 			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 			defer cancel()
 
-			opts := settings.SetSettingOptions{
+			opts := settings.SetSettingsOptions{
 				ConfigFlags: kubeConfigFlags,
-				Name:        settingName,
-				Value:       settingValue,
+				Names:       settingNames,
+				Values:      settingValues,
 				Verbosity:   globalConfig.GetVerbosity(),
 			}
 
-			if err := settings.SetSetting(ctx, opts); err != nil {
+			if err := settings.SetSettings(ctx, opts); err != nil {
 				return err
 			}
 
-			fmt.Printf("Setting '%s' updated to '%s'\n", settingName, settingValue)
+			for i, name := range settingNames {
+				fmt.Printf("Setting '%s' updated to '%s'\n", name, settingValues[i])
+			}
 			return nil
 		},
 	}
 
-	cmd.Flags().StringVar(&settingName, "setting", "", "Setting name")
-	cmd.Flags().StringVar(&settingValue, "value", "", "Setting value")
-	if err := cmd.MarkFlagRequired("setting"); err != nil {
-		_ = err
-	}
-	if err := cmd.MarkFlagRequired("value"); err != nil {
-		_ = err
-	}
+	cmd.Flags().StringArrayVar(&settingNames, "setting", nil, "Setting name (can be specified multiple times)")
+	cmd.Flags().StringArrayVar(&settingValues, "value", nil, "Setting value (can be specified multiple times)")
+
+	_ = cmd.MarkFlagRequired("setting")
+	_ = cmd.MarkFlagRequired("value")
 
 	_ = cmd.RegisterFlagCompletionFunc("setting", setSettingCompletion)
 	_ = cmd.RegisterFlagCompletionFunc("value", setValueCompletion)
@@ -97,8 +107,13 @@ func setSettingCompletion(cmd *cobra.Command, args []string, toComplete string) 
 
 // setValueCompletion provides completion for the --value flag based on the --setting flag.
 func setValueCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	settingName, _ := cmd.Flags().GetString("setting")
-	def := settings.GetSettingDefinition(settingName)
+	settingNameList, _ := cmd.Flags().GetStringArray("setting")
+	if len(settingNameList) == 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	// Use the last --setting value for context-sensitive completion
+	lastSettingName := settingNameList[len(settingNameList)-1]
+	def := settings.GetSettingDefinition(lastSettingName)
 	if def == nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}

--- a/pkg/cmd/settings/settings.go
+++ b/pkg/cmd/settings/settings.go
@@ -32,6 +32,14 @@ type SetSettingOptions struct {
 	Verbosity   int
 }
 
+// SetSettingsOptions contains options for setting multiple values in a single patch.
+type SetSettingsOptions struct {
+	ConfigFlags *genericclioptions.ConfigFlags
+	Names       []string
+	Values      []string
+	Verbosity   int
+}
+
 // UnsetSettingOptions contains options for unsetting a value.
 type UnsetSettingOptions struct {
 	ConfigFlags *genericclioptions.ConfigFlags
@@ -201,18 +209,45 @@ func extractSettingValue(spec map[string]interface{}, def SettingDefinition) Set
 }
 
 // SetSetting updates a ForkliftController setting.
+// It delegates to SetSettings to avoid duplicating patch logic.
 func SetSetting(ctx context.Context, opts SetSettingOptions) error {
-	// Validate setting name against all known settings
-	allSettings := GetAllSettings()
-	def, ok := allSettings[opts.Name]
-	if !ok {
-		return fmt.Errorf("unknown setting: %s\nUse 'kubectl mtv settings --all' to see available settings", opts.Name)
+	return SetSettings(ctx, SetSettingsOptions{
+		ConfigFlags: opts.ConfigFlags,
+		Names:       []string{opts.Name},
+		Values:      []string{opts.Value},
+		Verbosity:   opts.Verbosity,
+	})
+}
+
+// SetSettings updates multiple ForkliftController settings in a single patch operation.
+// This avoids multiple reconciliation cycles by merging all settings into one API call.
+func SetSettings(ctx context.Context, opts SetSettingsOptions) error {
+	if len(opts.Names) != len(opts.Values) {
+		return fmt.Errorf("number of --setting flags (%d) must match number of --value flags (%d)", len(opts.Names), len(opts.Values))
 	}
 
-	// Validate and convert the value
-	patchValue, err := validateAndConvertValue(opts.Value, def)
-	if err != nil {
-		return fmt.Errorf("invalid value for %s: %w", opts.Name, err)
+	seen := make(map[string]bool, len(opts.Names))
+	for _, name := range opts.Names {
+		if seen[name] {
+			return fmt.Errorf("duplicate setting: %s (each setting can only be specified once)", name)
+		}
+		seen[name] = true
+	}
+
+	// Validate all setting names and values upfront before making any changes
+	allSettings := GetAllSettings()
+	patchValues := make([]interface{}, len(opts.Names))
+	for i, name := range opts.Names {
+		def, ok := allSettings[name]
+		if !ok {
+			return fmt.Errorf("unknown setting: %s\nUse 'kubectl mtv settings --all' to see available settings", name)
+		}
+
+		patchValue, err := validateAndConvertValue(opts.Values[i], def)
+		if err != nil {
+			return fmt.Errorf("invalid value for setting '%s': %w", name, err)
+		}
+		patchValues[i] = patchValue
 	}
 
 	// Get the MTV operator namespace
@@ -241,12 +276,12 @@ func SetSetting(ctx context.Context, opts SetSettingOptions) error {
 	controller := controllerList.Items[0]
 	controllerName := controller.GetName()
 
-	// Create the patch data
-	patchMap := map[string]interface{}{
-		"spec": map[string]interface{}{
-			opts.Name: patchValue,
-		},
+	// Build one merged patch with all settings
+	specMap := map[string]interface{}{}
+	for i, name := range opts.Names {
+		specMap[name] = patchValues[i]
 	}
+	patchMap := map[string]interface{}{"spec": specMap}
 
 	patchData, err := json.Marshal(patchMap)
 	if err != nil {
@@ -257,7 +292,7 @@ func SetSetting(ctx context.Context, opts SetSettingOptions) error {
 		fmt.Printf("Patching ForkliftController '%s': %s\n", controllerName, string(patchData))
 	}
 
-	// Apply the patch
+	// Apply the single patch
 	_, err = dynamicClient.Resource(client.ForkliftControllersGVR).Namespace(operatorNamespace).Patch(
 		ctx,
 		controllerName,
@@ -266,7 +301,7 @@ func SetSetting(ctx context.Context, opts SetSettingOptions) error {
 		metav1.PatchOptions{},
 	)
 	if err != nil {
-		return wrapClusterError(err, "failed to update setting")
+		return wrapClusterError(err, "failed to update settings")
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

- Allow specifying multiple `--setting`/`--value` flags in a single `oc mtv settings set` invocation
- All settings are merged into one Kubernetes JSON Merge Patch, producing a single reconciliation cycle instead of N
- Validates all inputs upfront (unknown settings, invalid values, duplicate names) before patching
- `SetSetting` (singular) is preserved as a thin wrapper around `SetSettings` for backward compatibility

## Problem

Each `oc mtv settings set` call sends a separate patch, triggering a full Ansible reconciliation cycle (~64 tasks). Setting 3 values back-to-back causes 3 cycles with race conditions and incorrect intermediate states (see #239).

## Usage

```bash
# Before: 3 patches → 3 reconciliation cycles
oc mtv settings set --setting feature_mcp_server --value true
oc mtv settings set --setting mcp_server_lightspeed_set_mcp_gate --value true
oc mtv settings set --setting controller_max_vm_inflight --value 30

# After: 1 patch → 1 reconciliation cycle
oc mtv settings set --setting feature_mcp_server --value true \
                    --setting mcp_server_lightspeed_set_mcp_gate --value true \
                    --setting controller_max_vm_inflight --value 30
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test -race ./pkg/cmd/settings/... ./cmd/settings/...` passes
- [x] `go vet ./...` passes
- [ ] Manual test: single `--setting`/`--value` still works (backward compat)
- [ ] Manual test: multiple pairs produce one merged patch
- [ ] Manual test: duplicate `--setting` names return error
- [ ] Manual test: mismatched flag counts return error

Closes #239

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The settings command now supports updating multiple configuration options in a single operation. Users can specify multiple `--setting` and `--value` pairs simultaneously, improving efficiency when making batch configuration changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yaacov/kubectl-mtv/pull/240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->