### PR TITLE
adding to --delete-vm-on-fail-migration true or false option

### DIFF
--- a/cmd/patch/plan.go
+++ b/cmd/patch/plan.go
@@ -66,7 +66,7 @@ func NewPlanCmd(kubeConfigFlags *genericclioptions.ConfigFlags) *cobra.Command {
 	var archived bool
 	var pvcNameTemplateUseGenerateName bool
 	var deleteGuestConversionPod bool
-	var deleteVmOnFailMigration bool
+	var deleteVmOnFailMigration string
 	var skipGuestConversion bool
 	var warm bool
 	var runPreflightInspection bool
@@ -255,7 +255,7 @@ Affinity Syntax (KARL):
 	cmd.Flags().BoolVar(&archived, "archived", false, "Whether this plan should be archived")
 	cmd.Flags().BoolVar(&pvcNameTemplateUseGenerateName, "pvc-name-template-use-generate-name", true, "Use generateName instead of name for PVC name template")
 	cmd.Flags().BoolVar(&deleteGuestConversionPod, "delete-guest-conversion-pod", false, "Delete guest conversion pod after successful migration")
-	cmd.Flags().BoolVar(&deleteVmOnFailMigration, "delete-vm-on-fail-migration", false, "Delete target VM when migration fails")
+	cmd.Flags().StringVar(&deleteVmOnFailMigration, "delete-vm-on-fail-migration", "", "Delete target VM when migration fails (true/false)")
 	cmd.Flags().BoolVar(&skipGuestConversion, "skip-guest-conversion", false, "Skip the guest conversion process (raw disk copy mode)")
 	cmd.Flags().BoolVar(&warm, "warm", false, "Enable warm migration (use --migration-type=warm instead)")
 	cmd.Flags().BoolVar(&runPreflightInspection, "run-preflight-inspection", true, "Run preflight inspection on VM base disks before starting disk transfer")
@@ -280,6 +280,12 @@ Affinity Syntax (KARL):
 
 	if err := cmd.RegisterFlagCompletionFunc("enable-nested-virtualization", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"true", "false", "auto"}, cobra.ShellCompDirectiveNoFileComp
+	}); err != nil {
+		panic(err)
+	}
+
+	if err := cmd.RegisterFlagCompletionFunc("delete-vm-on-fail-migration", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"true", "false"}, cobra.ShellCompDirectiveNoFileComp
 	}); err != nil {
 		panic(err)
 	}
@@ -319,7 +325,7 @@ func NewPlanVMCmd(kubeConfigFlags *genericclioptions.ConfigFlags) *cobra.Command
 	var clearHooks bool
 
 	// Additional VM flags
-	var deleteVmOnFailMigration bool
+	var deleteVmOnFailMigration string
 	var deleteVmOnFailMigrationChanged bool
 	var nbdeClevis bool
 	var nbdeClevisChanged bool
@@ -385,7 +391,7 @@ func NewPlanVMCmd(kubeConfigFlags *genericclioptions.ConfigFlags) *cobra.Command
 	cmd.Flags().BoolVar(&clearHooks, "clear-hooks", false, "Remove all hooks from this VM")
 
 	// Additional VM flags
-	cmd.Flags().BoolVar(&deleteVmOnFailMigration, "delete-vm-on-fail-migration", false, "Delete target VM when migration fails (overrides plan-level setting)")
+	cmd.Flags().StringVar(&deleteVmOnFailMigration, "delete-vm-on-fail-migration", "", "Delete target VM when migration fails (true/false, overrides plan-level setting)")
 	cmd.Flags().BoolVar(&nbdeClevis, "nbde-clevis", false, "Enable passphrase-less NBDE/Clevis disk unlocking via TANG server (takes precedence over --luks-secret)")
 	cmd.Flags().StringVar(&enableNestedVirtualization, "enable-nested-virtualization", "", "Enable nested virtualization for this VM (true/false/auto)")
 	cmd.Flags().StringVar(&migrateSharedDisks, "migrate-shared-disks", "", "Migrate shared disks for this VM, overrides plan-level setting (true/false/auto)")
@@ -425,6 +431,12 @@ func NewPlanVMCmd(kubeConfigFlags *genericclioptions.ConfigFlags) *cobra.Command
 
 	if err := cmd.RegisterFlagCompletionFunc("rdm-as-lun", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"true", "false", "auto"}, cobra.ShellCompDirectiveNoFileComp
+	}); err != nil {
+		panic(err)
+	}
+
+	if err := cmd.RegisterFlagCompletionFunc("delete-vm-on-fail-migration", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"true", "false"}, cobra.ShellCompDirectiveNoFileComp
 	}); err != nil {
 		panic(err)
 	}

--- a/pkg/cmd/patch/plan/patch.go
+++ b/pkg/cmd/patch/plan/patch.go
@@ -60,7 +60,7 @@ type PatchPlanOptions struct {
 	Archived                       bool
 	PVCNameTemplateUseGenerateName bool
 	DeleteGuestConversionPod       bool
-	DeleteVmOnFailMigration        bool
+	DeleteVmOnFailMigration        string
 	SkipGuestConversion            bool
 	Warm                           bool
 	RunPreflightInspection         bool
@@ -467,9 +467,18 @@ func PatchPlan(opts PatchPlanOptions) error {
 
 	// Update delete VM on fail migration if flag was changed
 	if opts.DeleteVmOnFailMigrationChanged {
-		patchSpec["deleteVmOnFailMigration"] = opts.DeleteVmOnFailMigration
-		klog.V(2).Infof("Updated delete VM on fail migration to %t", opts.DeleteVmOnFailMigration)
-		planUpdated = true
+		switch strings.ToLower(opts.DeleteVmOnFailMigration) {
+		case "true":
+			patchSpec["deleteVmOnFailMigration"] = true
+			klog.V(2).Infof("Updated delete VM on fail migration to true")
+			planUpdated = true
+		case "false":
+			patchSpec["deleteVmOnFailMigration"] = false
+			klog.V(2).Infof("Updated delete VM on fail migration to false")
+			planUpdated = true
+		default:
+			return fmt.Errorf("invalid value for delete-vm-on-fail-migration: %s (must be 'true' or 'false')", opts.DeleteVmOnFailMigration)
+		}
 	}
 
 	// Update skip guest conversion if flag was changed
@@ -570,7 +579,7 @@ func PatchPlan(opts PatchPlanOptions) error {
 // PatchPlanVM patches a specific VM within a plan's VM list
 func PatchPlanVM(configFlags *genericclioptions.ConfigFlags, planName, vmName, namespace string,
 	targetName, rootDisk, instanceType, pvcNameTemplate, volumeNameTemplate, networkNameTemplate, luksSecret, targetPowerState string,
-	addPreHook, addPostHook, removeHook string, clearHooks bool, deleteVmOnFailMigration bool, deleteVmOnFailMigrationChanged bool,
+	addPreHook, addPostHook, removeHook string, clearHooks bool, deleteVmOnFailMigration string, deleteVmOnFailMigrationChanged bool,
 	nbdeClevis bool, nbdeClevisChanged bool, enableNestedVirtualization string, enableNestedVirtualizationChanged bool,
 	migrateSharedDisks string, migrateSharedDisksChanged bool, rdmAsLun string, rdmAsLunChanged bool) error {
 
@@ -720,12 +729,24 @@ func PatchPlanVM(configFlags *genericclioptions.ConfigFlags, planName, vmName, n
 
 	// Update delete VM on fail migration if flag was changed
 	if deleteVmOnFailMigrationChanged {
-		err = unstructured.SetNestedField(vmCopy, deleteVmOnFailMigration, "deleteVmOnFailMigration")
-		if err != nil {
-			return fmt.Errorf("failed to set delete VM on fail migration: %v", err)
+		switch strings.ToLower(deleteVmOnFailMigration) {
+		case "true":
+			err = unstructured.SetNestedField(vmCopy, true, "deleteVmOnFailMigration")
+			if err != nil {
+				return fmt.Errorf("failed to set delete VM on fail migration: %v", err)
+			}
+			klog.V(2).Infof("Updated VM delete on fail migration to true")
+			vmUpdated = true
+		case "false":
+			err = unstructured.SetNestedField(vmCopy, false, "deleteVmOnFailMigration")
+			if err != nil {
+				return fmt.Errorf("failed to set delete VM on fail migration: %v", err)
+			}
+			klog.V(2).Infof("Updated VM delete on fail migration to false")
+			vmUpdated = true
+		default:
+			return fmt.Errorf("invalid value for delete-vm-on-fail-migration: %s (must be 'true' or 'false')", deleteVmOnFailMigration)
 		}
-		klog.V(2).Infof("Updated VM delete on fail migration to %t", deleteVmOnFailMigration)
-		vmUpdated = true
 	}
 
 	// Update NBDE/Clevis if flag was changed


### PR DESCRIPTION
The --delete-vm-on-fail-migration flag on patch plan and patch planvm was a Cobra BoolVar. With
    boolean flags, --delete-vm-on-fail-migration false doesn't work — Cobra treats false as a positional
    argument and silently sets the flag to true. Only the = syntax (--delete-vm-on-fail-migration=false)
    worked, which is unintuitive.

    Changed the flag to StringVar so it naturally accepts --delete-vm-on-fail-migration true and
    --delete-vm-on-fail-migration false. Added input validation and shell completions. Follows the same
    pattern already used by --enable-nested-virtualization in the same file.

    Files changed:
    - cmd/patch/plan.go — flag type + shell completions for both patch plan and patch planvm
    - pkg/cmd/patch/plan/patch.go — options struct, plan-level patch logic, VM-level patch logic and
    function signature


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shell completion support with "true"/"false" options for the `delete-vm-on-fail-migration` parameter in patch operations.

* **Changes**
  * Converted the `delete-vm-on-fail-migration` parameter to accept string values ("true"/"false") instead of boolean input format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->