### PR TITLE
refactor(cli)!: require explicit true/false value for boolean toggle …

### DIFF
--- a/cmd/create/plan.go
+++ b/cmd/create/plan.go
@@ -194,7 +194,14 @@ Affinity Syntax (KARL):
     --source vsphere-prod \
     --vms "where name ~= 'test-.*'" \
     --default-target-network default \
-    --default-target-storage-class standard`,
+    --default-target-storage-class standard
+
+  # Disable default-true boolean flags with explicit false
+  kubectl-mtv create plan --name no-preflight \
+    --source vsphere-prod \
+    --vms "quick-vm" \
+    --run-preflight-inspection false \
+    --preserve-static-ips false`,
 		Args:         cobra.MaximumNArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -570,22 +577,22 @@ Affinity Syntax (KARL):
 	cmd.Flags().StringVar(&planSpec.TargetNamespace, "target-namespace", "", "Target namespace (defaults to plan namespace)")
 	cmd.Flags().StringVar(&transferNetwork, "transfer-network", "", "Network attachment definition for disk transfer. Supports 'namespace/network-name' or 'network-name'")
 	cmd.Flags().BoolVar(&planSpec.PreserveClusterCPUModel, "preserve-cluster-cpu-model", false, "Preserve the CPU model and flags the VM runs with in its cluster")
-	cmd.Flags().BoolVar(&planSpec.PreserveStaticIPs, "preserve-static-ips", true, "Preserve static IP configurations during migration")
+	flags.ExplicitBoolVar(cmd.Flags(), &planSpec.PreserveStaticIPs, "preserve-static-ips", true, "Preserve static IP configurations during migration (true/false)")
 	cmd.Flags().StringVar(&planSpec.PVCNameTemplate, "pvc-name-template", "", "Template for generating PVC names. Variables: {{.VmName}}, {{.PlanName}}, {{.DiskIndex}}, {{.WinDriveLetter}}, {{.RootDiskIndex}}, {{.Shared}}, {{.FileName}}")
 	cmd.Flags().StringVar(&planSpec.VolumeNameTemplate, "volume-name-template", "", "Template for generating volume interface names in the target VM. Variables: {{.PVCName}}, {{.VolumeIndex}}")
 	cmd.Flags().StringVar(&planSpec.NetworkNameTemplate, "network-name-template", "", "Template for generating network interface names in the target VM. Variables: {{.NetworkName}}, {{.NetworkNamespace}}, {{.NetworkType}}, {{.NetworkIndex}}")
-	cmd.Flags().BoolVar(&planSpec.MigrateSharedDisks, "migrate-shared-disks", true, "Migrate disks shared between multiple VMs")
+	flags.ExplicitBoolVar(cmd.Flags(), &planSpec.MigrateSharedDisks, "migrate-shared-disks", true, "Migrate disks shared between multiple VMs (true/false)")
 	cmd.Flags().BoolVar(&planSpec.Archived, "archived", false, "Whether this plan should be archived")
-	cmd.Flags().BoolVar(&planSpec.PVCNameTemplateUseGenerateName, "pvc-name-template-use-generate-name", true, "Use generateName instead of name for PVC name template")
+	flags.ExplicitBoolVar(cmd.Flags(), &planSpec.PVCNameTemplateUseGenerateName, "pvc-name-template-use-generate-name", true, "Use generateName instead of name for PVC name template (true/false)")
 	cmd.Flags().BoolVar(&planSpec.DeleteGuestConversionPod, "delete-guest-conversion-pod", false, "Delete guest conversion pod after successful migration")
-	cmd.Flags().BoolVar(&planSpec.DeleteVmOnFailMigration, "delete-vm-on-fail-migration", true, "Delete target VM when migration fails")
+	flags.ExplicitBoolVar(cmd.Flags(), &planSpec.DeleteVmOnFailMigration, "delete-vm-on-fail-migration", true, "Delete target VM when migration fails (true/false)")
 	cmd.Flags().BoolVar(&planSpec.SkipGuestConversion, "skip-guest-conversion", false, "Skip the guest conversion process (raw disk copy mode)")
-	cmd.Flags().BoolVar(&planSpec.RunPreflightInspection, "run-preflight-inspection", true, "Run preflight inspection on VM base disks before starting disk transfer")
+	flags.ExplicitBoolVar(cmd.Flags(), &planSpec.RunPreflightInspection, "run-preflight-inspection", true, "Run preflight inspection on VM base disks before starting disk transfer (true/false)")
 	cmd.Flags().StringVar(&installLegacyDrivers, "install-legacy-drivers", "auto", "Install legacy Windows drivers (true/false/auto)")
 	cmd.Flags().VarP(migrationTypeFlag, "migration-type", "m", "Migration type: cold, warm, live, or conversion (default: cold)")
 	cmd.Flags().StringVarP(&defaultTargetNetwork, "default-target-network", "N", "", "Default target network for auto-generated mapping. Use 'default' for pod networking, 'namespace/network-name', or 'network-name'")
 	cmd.Flags().StringVar(&defaultTargetStorageClass, "default-target-storage-class", "", "Default target storage class for auto-generated mapping")
-	cmd.Flags().BoolVar(&useCompatibilityMode, "use-compatibility-mode", true, "Use compatibility devices (SATA bus, E1000E NIC) when skipGuestConversion is true")
+	flags.ExplicitBoolVar(cmd.Flags(), &useCompatibilityMode, "use-compatibility-mode", true, "Use compatibility devices (SATA bus, E1000E NIC) when skipGuestConversion is true (true/false)")
 	cmd.Flags().StringSliceVarP(&targetLabels, "target-labels", "L", nil, "Target labels to be added to the VM (e.g., key1=value1,key2=value2)")
 	cmd.Flags().StringSliceVar(&targetNodeSelector, "target-node-selector", nil, "Target node selector to constrain VM scheduling (e.g., key1=value1,key2=value2)")
 	cmd.Flags().BoolVar(&planSpec.Warm, "warm", false, "Enable warm migration (use --migration-type=warm instead)")

--- a/cmd/help/help.go
+++ b/cmd/help/help.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/yaacov/kubectl-mtv/pkg/cmd/help"
+	"github.com/yaacov/kubectl-mtv/pkg/util/flags"
 )
 
 // NewHelpCmd creates the help command with machine-readable output support.
@@ -123,7 +124,7 @@ Help topics are also available for domain-specific languages:
 	cmd.Flags().StringVarP(&outputFormat, "output", "o", "json", "Output format for --machine: json, yaml")
 	cmd.Flags().BoolVar(&readOnly, "read-only", false, "Include only read-only commands (with --machine)")
 	cmd.Flags().BoolVar(&write, "write", false, "Include only write commands (with --machine)")
-	cmd.Flags().BoolVar(&includeGlobalFlags, "include-global-flags", true, "Include global flags in output (with --machine)")
+	flags.ExplicitBoolVar(cmd.Flags(), &includeGlobalFlags, "include-global-flags", true, "Include global flags in output (with --machine) (true/false)")
 
 	// Add completion for output format flag
 	if err := cmd.RegisterFlagCompletionFunc("output", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/patch/plan.go
+++ b/cmd/patch/plan.go
@@ -107,8 +107,11 @@ Affinity Syntax (KARL):
   # Update transfer network
   kubectl-mtv patch plan --plan-name my-migration --transfer-network my-namespace/migration-net
 
-  # Add target labels to migrated VMs
-  kubectl-mtv patch plan --plan-name my-migration --target-labels env=prod,team=platform
+  # Disable static IP preservation
+  kubectl-mtv patch plan --plan-name my-migration --preserve-static-ips false
+
+  # Enable raw disk copy mode (skip guest conversion)
+  kubectl-mtv patch plan --plan-name my-migration --skip-guest-conversion true
 
   # Configure convertor pod scheduling
   kubectl-mtv patch plan --plan-name my-migration --convertor-node-selector node-role=worker`,
@@ -225,7 +228,7 @@ Affinity Syntax (KARL):
 	cmd.Flags().Var(migrationTypeFlag, "migration-type", "Migration type: cold, warm, live, or conversion")
 	cmd.Flags().StringSliceVar(&targetLabels, "target-labels", []string{}, "Target VM labels in format key=value (can be specified multiple times)")
 	cmd.Flags().StringSliceVar(&targetNodeSelector, "target-node-selector", []string{}, "Target node selector in format key=value (can be specified multiple times)")
-	cmd.Flags().BoolVar(&useCompatibilityMode, "use-compatibility-mode", false, "Use compatibility devices (SATA bus, E1000E NIC) when skipGuestConversion is true")
+	flags.ExplicitBoolVar(cmd.Flags(), &useCompatibilityMode, "use-compatibility-mode", false, "Use compatibility devices (SATA bus, E1000E NIC) when skipGuestConversion is true (true/false)")
 	cmd.Flags().StringVar(&targetAffinity, "target-affinity", "", "Target affinity using KARL syntax (e.g. 'REQUIRE pods(app=database) on node')")
 	cmd.Flags().StringVar(&targetNamespace, "target-namespace", "", "Target namespace for migrated VMs")
 	cmd.Flags().StringVar(&targetPowerState, "target-power-state", "", "Target power state for VMs after migration: 'on', 'off', or 'auto' (default: match source VM power state)")
@@ -238,30 +241,30 @@ Affinity Syntax (KARL):
 	// Conversion temporary storage flags (providers requiring guest conversion)
 	cmd.Flags().StringVar(&conversionTempStorageClass, "conversion-temp-storage-class", "", "Storage class for temporary conversion PVCs (useful for large VM migrations where node ephemeral storage is insufficient)")
 	cmd.Flags().StringVar(&conversionTempStorageSize, "conversion-temp-storage-size", "", "Size of temporary conversion PVC, e.g. '30Gi' or '1Ti' (only used when --conversion-temp-storage-class is set)")
-	cmd.Flags().BoolVar(&skipZoneNodeSelector, "skip-zone-node-selector", false, "Skip adding zone-based node selector to migrated VMs (EC2 only)")
+	flags.ExplicitBoolVar(cmd.Flags(), &skipZoneNodeSelector, "skip-zone-node-selector", false, "Skip adding zone-based node selector to migrated VMs (EC2 only) (true/false)")
 	cmd.Flags().StringVar(&customizationScripts, "customization-scripts", "", "ConfigMap containing customization scripts for guest conversion. Supports 'namespace/name' or 'name'")
 	cmd.Flags().StringVar(&virtV2vImage, "virt-v2v-image", "", "Override global virt-v2v container image for this plan")
 	cmd.Flags().StringVar(&enableNestedVirtualization, "enable-nested-virtualization", "", "Enable nested virtualization on target VMs (true/false/auto)")
-	cmd.Flags().BoolVar(&xfsCompatibility, "xfs-compatibility", false, "Use XFS-compatible virt-v2v image for this plan")
+	flags.ExplicitBoolVar(cmd.Flags(), &xfsCompatibility, "xfs-compatibility", false, "Use XFS-compatible virt-v2v image for this plan (true/false)")
 
 	// Plan metadata and configuration flags
 	cmd.Flags().StringVar(&description, "description", "", "Plan description")
-	cmd.Flags().BoolVar(&preserveClusterCPUModel, "preserve-cluster-cpu-model", false, "Preserve the CPU model and flags the VM runs with in its cluster")
-	cmd.Flags().BoolVar(&preserveStaticIPs, "preserve-static-ips", false, "Preserve static IP configurations during migration")
+	flags.ExplicitBoolVar(cmd.Flags(), &preserveClusterCPUModel, "preserve-cluster-cpu-model", false, "Preserve the CPU model and flags the VM runs with in its cluster (true/false)")
+	flags.ExplicitBoolVar(cmd.Flags(), &preserveStaticIPs, "preserve-static-ips", false, "Preserve static IP configurations during migration (true/false)")
 	cmd.Flags().StringVar(&pvcNameTemplate, "pvc-name-template", "", "Template for generating PVC names for VM disks. Variables: {{.VmName}}, {{.PlanName}}, {{.DiskIndex}}, {{.WinDriveLetter}}, {{.RootDiskIndex}}, {{.Shared}}, {{.FileName}}")
 	cmd.Flags().StringVar(&volumeNameTemplate, "volume-name-template", "", "Template for generating volume interface names in the target VM. Variables: {{.PVCName}}, {{.VolumeIndex}}")
 	cmd.Flags().StringVar(&networkNameTemplate, "network-name-template", "", "Template for generating network interface names in the target VM. Variables: {{.NetworkName}}, {{.NetworkNamespace}}, {{.NetworkType}}, {{.NetworkIndex}}")
-	cmd.Flags().BoolVar(&migrateSharedDisks, "migrate-shared-disks", true, "Migrate disks shared between multiple VMs")
-	cmd.Flags().BoolVar(&archived, "archived", false, "Whether this plan should be archived")
-	cmd.Flags().BoolVar(&pvcNameTemplateUseGenerateName, "pvc-name-template-use-generate-name", true, "Use generateName instead of name for PVC name template")
-	cmd.Flags().BoolVar(&deleteGuestConversionPod, "delete-guest-conversion-pod", false, "Delete guest conversion pod after successful migration")
+	flags.ExplicitBoolVar(cmd.Flags(), &migrateSharedDisks, "migrate-shared-disks", true, "Migrate disks shared between multiple VMs (true/false)")
+	flags.ExplicitBoolVar(cmd.Flags(), &archived, "archived", false, "Whether this plan should be archived (true/false)")
+	flags.ExplicitBoolVar(cmd.Flags(), &pvcNameTemplateUseGenerateName, "pvc-name-template-use-generate-name", true, "Use generateName instead of name for PVC name template (true/false)")
+	flags.ExplicitBoolVar(cmd.Flags(), &deleteGuestConversionPod, "delete-guest-conversion-pod", false, "Delete guest conversion pod after successful migration (true/false)")
 	cmd.Flags().StringVar(&deleteVmOnFailMigration, "delete-vm-on-fail-migration", "", "Delete target VM when migration fails (true/false)")
-	cmd.Flags().BoolVar(&skipGuestConversion, "skip-guest-conversion", false, "Skip the guest conversion process (raw disk copy mode)")
-	cmd.Flags().BoolVar(&warm, "warm", false, "Enable warm migration (use --migration-type=warm instead)")
-	cmd.Flags().BoolVar(&runPreflightInspection, "run-preflight-inspection", true, "Run preflight inspection on VM base disks before starting disk transfer")
-	cmd.Flags().BoolVar(&rdmAsLun, "rdm-as-lun", false, "Map VMware RDM disks as LUN devices (SCSI passthrough) in the target VM (vSphere only)")
+	flags.ExplicitBoolVar(cmd.Flags(), &skipGuestConversion, "skip-guest-conversion", false, "Skip the guest conversion process (raw disk copy mode) (true/false)")
+	flags.ExplicitBoolVar(cmd.Flags(), &warm, "warm", false, "Enable warm migration (use --migration-type=warm instead) (true/false)")
+	flags.ExplicitBoolVar(cmd.Flags(), &runPreflightInspection, "run-preflight-inspection", true, "Run preflight inspection on VM base disks before starting disk transfer (true/false)")
+	flags.ExplicitBoolVar(cmd.Flags(), &rdmAsLun, "rdm-as-lun", false, "Map VMware RDM disks as LUN devices (SCSI passthrough) in the target VM (vSphere only) (true/false)")
 	cmd.Flags().StringVar(&serviceAccount, "service-account", "", "ServiceAccount for migration pods in the target namespace (overrides global setting)")
-	cmd.Flags().BoolVar(&tagMappingDisabled, "tag-mapping-disabled", false, "Disable vSphere tag-to-label conversion entirely (vSphere only)")
+	flags.ExplicitBoolVar(cmd.Flags(), &tagMappingDisabled, "tag-mapping-disabled", false, "Disable vSphere tag-to-label conversion entirely (vSphere only) (true/false)")
 	cmd.Flags().StringSliceVar(&tagMappingLabelTags, "tag-mapping-label-tags", nil, "Only convert these vSphere tag categories to labels (comma-separated, vSphere only)")
 
 	// Add completion for migration type flag
@@ -392,7 +395,7 @@ func NewPlanVMCmd(kubeConfigFlags *genericclioptions.ConfigFlags) *cobra.Command
 
 	// Additional VM flags
 	cmd.Flags().StringVar(&deleteVmOnFailMigration, "delete-vm-on-fail-migration", "", "Delete target VM when migration fails (true/false, overrides plan-level setting)")
-	cmd.Flags().BoolVar(&nbdeClevis, "nbde-clevis", false, "Enable passphrase-less NBDE/Clevis disk unlocking via TANG server (takes precedence over --luks-secret)")
+	flags.ExplicitBoolVar(cmd.Flags(), &nbdeClevis, "nbde-clevis", false, "Enable passphrase-less NBDE/Clevis disk unlocking via TANG server (takes precedence over --luks-secret) (true/false)")
 	cmd.Flags().StringVar(&enableNestedVirtualization, "enable-nested-virtualization", "", "Enable nested virtualization for this VM (true/false/auto)")
 	cmd.Flags().StringVar(&migrateSharedDisks, "migrate-shared-disks", "", "Migrate shared disks for this VM, overrides plan-level setting (true/false/auto)")
 	cmd.Flags().StringVar(&rdmAsLunVM, "rdm-as-lun", "", "Map VMware RDM disks as LUN devices for this VM, overrides plan-level setting (vSphere only, true/false/auto)")

--- a/cmd/patch/provider.go
+++ b/cmd/patch/provider.go
@@ -72,14 +72,14 @@ func NewProviderCmd(kubeConfigFlags *genericclioptions.ConfigFlags) *cobra.Comma
 	cmd.Flags().StringVarP(&opts.Username, "username", "u", "", "Provider credentials username")
 	cmd.Flags().StringVarP(&opts.Password, "password", "p", "", "Provider credentials password")
 	cmd.Flags().StringVar(&opts.CACert, "cacert", "", "Provider CA certificate (use @filename to load from file)")
-	cmd.Flags().BoolVar(&opts.InsecureSkipTLS, "provider-insecure-skip-tls", false, "Skip TLS verification when connecting to the provider")
+	flags.ExplicitBoolVar(cmd.Flags(), &opts.InsecureSkipTLS, "provider-insecure-skip-tls", false, "Skip TLS verification when connecting to the provider (true/false)")
 
 	// OpenShift specific flags
 	cmd.Flags().StringVarP(&opts.Token, "provider-token", "T", "", "Provider authentication token")
 
 	// vSphere specific flags (editable VDDK settings)
 	cmd.Flags().StringVar(&opts.VddkInitImage, "vddk-init-image", "", "Virtual Disk Development Kit (VDDK) container init image path")
-	cmd.Flags().BoolVar(&opts.UseVddkAioOptimization, "use-vddk-aio-optimization", false, "Enable VDDK AIO optimization for improved disk transfer performance")
+	flags.ExplicitBoolVar(cmd.Flags(), &opts.UseVddkAioOptimization, "use-vddk-aio-optimization", false, "Enable VDDK AIO optimization for improved disk transfer performance (true/false)")
 	cmd.Flags().IntVar(&opts.VddkBufSizeIn64K, "vddk-buf-size-in-64k", 0, "VDDK buffer size in 64K units (VixDiskLib.nfcAio.Session.BufSizeIn64K)")
 	cmd.Flags().IntVar(&opts.VddkBufCount, "vddk-buf-count", 0, "VDDK buffer count (VixDiskLib.nfcAio.Session.BufCount)")
 	cmd.Flags().Var(esxiCloneMethod, "esxi-clone-method", "ESXi clone method for vSphere provider (vib or ssh)")
@@ -101,7 +101,7 @@ func NewProviderCmd(kubeConfigFlags *genericclioptions.ConfigFlags) *cobra.Comma
 	cmd.Flags().StringVar(&opts.EC2TargetAZ, "target-az", "", "Target availability zone for migrations (auto-detected from worker nodes if omitted)")
 	cmd.Flags().StringVar(&opts.EC2TargetAccessKeyID, "target-access-key-id", "", "Target AWS account access key ID (for cross-account migrations)")
 	cmd.Flags().StringVar(&opts.EC2TargetSecretKey, "target-secret-access-key", "", "Target AWS account secret access key (for cross-account migrations)")
-	cmd.Flags().BoolVar(&opts.AutoTargetCredentials, "auto-target-credentials", false, "Automatically fetch target AWS credentials from cluster and target-az from worker nodes")
+	flags.ExplicitBoolVar(cmd.Flags(), &opts.AutoTargetCredentials, "auto-target-credentials", false, "Automatically fetch target AWS credentials from cluster and target-az from worker nodes (true/false)")
 
 	_ = cmd.RegisterFlagCompletionFunc("name", completion.ProviderNameCompletion(kubeConfigFlags))
 	_ = cmd.RegisterFlagCompletionFunc("esxi-clone-method", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {

--- a/guide/05-conversion-migration.md
+++ b/guide/05-conversion-migration.md
@@ -355,7 +355,7 @@ kubectl mtv create plan --name advanced-conversion-plan \
   --description "Conversion migration with vendor-provided storage" \
   --target-namespace migrated-workloads \
   --network-mapping production-network-mapping \
-  --preserve-static-ips \
+  --preserve-static-ips true \
   --target-power-state on \
   --vms "production-database,production-webserver"
 ```

--- a/guide/06-provider-management.md
+++ b/guide/06-provider-management.md
@@ -436,7 +436,7 @@ kubectl mtv patch provider --name vsphere-prod \
 # Update URL and disable TLS verification
 kubectl mtv patch provider --name vsphere-test \
   --url https://test-vcenter.internal/sdk \
-  --provider-insecure-skip-tls
+  --provider-insecure-skip-tls true
 
 # Update token for OpenShift provider
 kubectl mtv patch provider --name remote-openshift \
@@ -514,7 +514,7 @@ kubectl mtv patch provider --name vsphere-prod \
 
 # Enable VDDK AIO optimization
 kubectl mtv patch provider --name vsphere-prod \
-  --use-vddk-aio-optimization
+  --use-vddk-aio-optimization true
 
 # Update VDDK buffer settings
 kubectl mtv patch provider --name vsphere-prod \
@@ -523,7 +523,7 @@ kubectl mtv patch provider --name vsphere-prod \
 
 # Disable VDDK AIO optimization
 kubectl mtv patch provider --name vsphere-prod \
-  --use-vddk-aio-optimization=false
+  --use-vddk-aio-optimization false
 ```
 
 #### Update ESXi Clone Method (vSphere Only)
@@ -775,7 +775,7 @@ kubectl mtv patch provider --name vsphere-prod \
 
 # Temporarily disable TLS for testing
 kubectl mtv patch provider --name vsphere-test \
-  --provider-insecure-skip-tls
+  --provider-insecure-skip-tls true
 ```
 
 ### Provider Status and Health

--- a/guide/13-migration-plan-creation.md
+++ b/guide/13-migration-plan-creation.md
@@ -407,7 +407,7 @@ kubectl mtv create plan --name auto-power \
 kubectl mtv create plan --name linux-migration \
   --source vsphere-prod \
   --skip-guest-conversion \
-  --use-compatibility-mode \
+  --use-compatibility-mode true \
   --vms "where guestOS ~= '.*linux.*'"
 
 # Enable guest conversion with cleanup
@@ -429,13 +429,13 @@ kubectl mtv create plan --name legacy-windows \
 # Preserve static IPs (vSphere only)
 kubectl mtv create plan --name preserve-ips \
   --source vsphere-prod \
-  --preserve-static-ips \
+  --preserve-static-ips true \
   --vms "database-01,web-lb-01"
 
 # Disable IP preservation
 kubectl mtv create plan --name new-ips \
   --source vsphere-prod \
-  --preserve-static-ips=false \
+  --preserve-static-ips false \
   --vms "test-vm-01,dev-vm-01"
 ```
 
@@ -466,13 +466,13 @@ kubectl mtv create plan --name convertor-affinity \
 # Include shared disks in migration
 kubectl mtv create plan --name shared-disks \
   --source vsphere-prod \
-  --migrate-shared-disks \
+  --migrate-shared-disks true \
   --vms "cluster-vm-01,cluster-vm-02"
 
 # Exclude shared disks
 kubectl mtv create plan --name no-shared-disks \
   --source vsphere-prod \
-  --migrate-shared-disks=false \
+  --migrate-shared-disks false \
   --vms "standalone-vm-01"
 ```
 
@@ -483,14 +483,14 @@ kubectl mtv create plan --name no-shared-disks \
 kubectl mtv create plan --name warm-with-preflight \
   --source vsphere-prod \
   --migration-type warm \
-  --run-preflight-inspection \
+  --run-preflight-inspection true \
   --vms "critical-database-01"
 
 # Disable preflight for faster warm start
 kubectl mtv create plan --name warm-no-preflight \
   --source vsphere-prod \
   --migration-type warm \
-  --run-preflight-inspection=false \
+  --run-preflight-inspection false \
   --vms "test-warm-vm-01"
 ```
 

--- a/guide/14-customizing-individual-vms-planvms-format.md
+++ b/guide/14-customizing-individual-vms-planvms-format.md
@@ -617,7 +617,7 @@ kubectl mtv create plan --name comprehensive-migration \
   --source vsphere-prod \
   --target-namespace production \
   --migration-type warm \
-  --preserve-static-ips \
+  --preserve-static-ips true \
   --vms @enterprise-vms.yaml
 ```
 

--- a/guide/18-advanced-plan-patching.md
+++ b/guide/18-advanced-plan-patching.md
@@ -148,28 +148,28 @@ Control various aspects of the migration process:
 ```bash
 # Enable static IP preservation for vSphere VMs
 kubectl mtv patch plan --plan-name vsphere-production \
-  --preserve-static-ips=true
+  --preserve-static-ips true
 
 # Configure shared disk migration
 kubectl mtv patch plan --plan-name cluster-workloads \
-  --migrate-shared-disks=true
+  --migrate-shared-disks true
 
 # Enable compatibility mode for older systems
 kubectl mtv patch plan --plan-name legacy-systems \
-  --use-compatibility-mode=true
+  --use-compatibility-mode true
 
 # Configure cleanup behavior
 kubectl mtv patch plan --plan-name test-migration \
-  --delete-guest-conversion-pod=true \
-  --delete-vm-on-fail-migration=true
+  --delete-guest-conversion-pod true \
+  --delete-vm-on-fail-migration true
 
 # Skip guest conversion for specific use cases
 kubectl mtv patch plan --plan-name raw-disk-migration \
-  --skip-guest-conversion=true
+  --skip-guest-conversion true
 
 # Disable preflight inspection for faster warm migrations
 kubectl mtv patch plan --plan-name urgent-migration \
-  --run-preflight-inspection=false
+  --run-preflight-inspection false
 ```
 
 ### Conversion and Guest Conversion Configuration
@@ -192,7 +192,7 @@ kubectl mtv patch plan --plan-name custom-v2v-migration \
 
 # Skip zone node selector for EC2 migrations (EC2 only)
 kubectl mtv patch plan --plan-name ec2-migration \
-  --skip-zone-node-selector=true
+  --skip-zone-node-selector true
 ```
 
 ### Comprehensive Plan Update Example
@@ -211,11 +211,11 @@ kubectl mtv patch plan --plan-name enterprise-migration \
   --convertor-labels "migration=production,performance=optimized" \
   --convertor-node-selector "node-type=high-io,network=10gbe" \
   --convertor-affinity "REQUIRE nodes(storage-tier=premium) on node" \
-  --preserve-static-ips=true \
-  --preserve-cluster-cpu-model=true \
+  --preserve-static-ips true \
+  --preserve-cluster-cpu-model true \
   --pvc-name-template "prod-{% raw %}{{.TargetVmName}}{% endraw %}-{% raw %}{{.DiskIndex}}{% endraw %}" \
-  --delete-guest-conversion-pod=true \
-  --run-preflight-inspection=true
+  --delete-guest-conversion-pod true \
+  --run-preflight-inspection true
 ```
 
 ## How-To: Patching Individual VMs
@@ -271,11 +271,11 @@ kubectl mtv patch planvm --plan-name secure-migration --vm-name encrypted-databa
 
 # Enable NBDE/Clevis passphrase-less disk unlocking via TANG server
 kubectl mtv patch planvm --plan-name secure-migration --vm-name nbde-encrypted-vm \
-  --nbde-clevis=true
+  --nbde-clevis true
 
 # Override plan-level deletion policy for specific VM
 kubectl mtv patch planvm --plan-name test-migration --vm-name experimental-vm \
-  --delete-vm-on-fail-migration=true
+  --delete-vm-on-fail-migration true
 ```
 
 ### Adding and Managing Hooks
@@ -330,7 +330,7 @@ kubectl mtv patch planvm --plan-name enterprise-migration --vm-name critical-dat
   --volume-name-template "{% raw %}{{.TargetVmName}}{% endraw %}-storage-{% raw %}{{.VolumeIndex}}{% endraw %}" \
   --network-name-template "{% raw %}{{.TargetVmName}}{% endraw %}-net-{% raw %}{{.NetworkIndex}}{% endraw %}" \
   --luks-secret database-encryption-secret \
-  --delete-vm-on-fail-migration=false \
+  --delete-vm-on-fail-migration false \
   --add-pre-hook database-cluster-quiesce \
   --add-post-hook database-cluster-validate
 ```
@@ -348,7 +348,7 @@ kubectl mtv create plan --name evolving-migration \
 # Evolve to warm migration after testing
 kubectl mtv patch plan --plan-name evolving-migration \
   --migration-type warm \
-  --run-preflight-inspection=true
+  --run-preflight-inspection true
 
 # Add convertor optimization for warm migration
 kubectl mtv patch plan --plan-name evolving-migration \
@@ -423,8 +423,8 @@ kubectl mtv patch plan --plan-name dev-migration \
   --target-namespace development \
   --target-labels "environment=dev,auto-shutdown=true" \
   --target-power-state off \
-  --delete-vm-on-fail-migration=true \
-  --delete-guest-conversion-pod=true
+  --delete-vm-on-fail-migration true \
+  --delete-guest-conversion-pod true
 
 # Production environment configuration  
 kubectl mtv patch plan --plan-name prod-migration \
@@ -432,9 +432,9 @@ kubectl mtv patch plan --plan-name prod-migration \
   --target-labels "environment=prod,backup=required,monitoring=critical" \
   --target-node-selector "node-role.kubernetes.io/production=true" \
   --target-affinity "REQUIRE nodes(reliability-tier=high) on node" \
-  --preserve-static-ips=true \
-  --preserve-cluster-cpu-model=true \
-  --delete-vm-on-fail-migration=false
+  --preserve-static-ips true \
+  --preserve-cluster-cpu-model true \
+  --delete-vm-on-fail-migration false
 ```
 
 ## Patching with Provider Updates

--- a/guide/26-command-reference.md
+++ b/guide/26-command-reference.md
@@ -874,7 +874,7 @@ kubectl mtv patch planvm --plan-name my-migration --vm-name vm-db-01 \
 
 # Enable NBDE/Clevis for encrypted VM
 kubectl mtv patch planvm --plan-name my-migration --vm-name vm-encrypted \
-  --nbde-clevis=true
+  --nbde-clevis true
 ```
 
 #### patch mapping --name MAPPING_NAME

--- a/pkg/cmd/help/generator_test.go
+++ b/pkg/cmd/help/generator_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"github.com/yaacov/kubectl-mtv/pkg/util/flags"
 )
 
 // --- helpers ---
@@ -407,6 +409,36 @@ func TestFlagToSchema_BoolTrue(t *testing.T) {
 	schema := flagToSchema(f)
 	if def, ok := schema.Default.(bool); !ok || def != true {
 		t.Errorf("expected default true, got %v", schema.Default)
+	}
+}
+
+func TestFlagToSchema_ExplicitBoolTrue(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	var val bool
+	flags.ExplicitBoolVar(cmd.Flags(), &val, "migrate-shared-disks", true, "Migrate shared disks (true/false)")
+	f := cmd.Flags().Lookup("migrate-shared-disks")
+
+	schema := flagToSchema(f)
+	if schema.Type != "bool" {
+		t.Errorf("expected type 'bool', got %q", schema.Type)
+	}
+	if def, ok := schema.Default.(bool); !ok || def != true {
+		t.Errorf("expected default true, got %v (type %T)", schema.Default, schema.Default)
+	}
+}
+
+func TestFlagToSchema_ExplicitBoolFalse(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	var val bool
+	flags.ExplicitBoolVar(cmd.Flags(), &val, "skip-guest-conversion", false, "Skip guest conversion (true/false)")
+	f := cmd.Flags().Lookup("skip-guest-conversion")
+
+	schema := flagToSchema(f)
+	if schema.Type != "bool" {
+		t.Errorf("expected type 'bool', got %q", schema.Type)
+	}
+	if def, ok := schema.Default.(bool); !ok || def != false {
+		t.Errorf("expected default false, got %v (type %T)", schema.Default, schema.Default)
 	}
 }
 

--- a/pkg/mcp/tools/mtv_read.go
+++ b/pkg/mcp/tools/mtv_read.go
@@ -331,8 +331,7 @@ func buildArgs(cmdPath string, flags map[string]any) []string {
 
 // appendNormalizedFlags appends flags from a map[string]any to the args slice.
 // It handles different value types:
-//   - bool true: includes the flag with no value (presence flag)
-//   - bool false: explicitly passes --flag=false (needed for flags that default to true)
+//   - bool true/false: passes --flag true or --flag false (space-separated)
 //   - string "true"/"false": treated as boolean
 //   - string/number: converted to string form
 //
@@ -358,20 +357,15 @@ func appendNormalizedFlags(args []string, flags map[string]any, skipFlags map[st
 		switch v := value.(type) {
 		case bool:
 			if v {
-				// Boolean true: include flag with no value
-				args = append(args, prefix+name)
+				args = append(args, prefix+name, "true")
 			} else {
-				// Boolean false: explicitly pass --flag=false
-				// This is needed for flags that default to true (e.g., --migrate-shared-disks)
-				args = append(args, prefix+name+"=false")
+				args = append(args, prefix+name, "false")
 			}
 		case string:
-			// Handle string "true"/"false" as boolean for backwards compatibility
 			if v == "true" {
-				args = append(args, prefix+name)
+				args = append(args, prefix+name, "true")
 			} else if v == "false" {
-				// Explicitly pass --flag=false for flags that default to true
-				args = append(args, prefix+name+"=false")
+				args = append(args, prefix+name, "false")
 			} else if v != "" {
 				args = append(args, prefix+name, v)
 			}

--- a/pkg/mcp/tools/mtv_read_test.go
+++ b/pkg/mcp/tools/mtv_read_test.go
@@ -217,24 +217,24 @@ func TestAppendNormalizedFlags(t *testing.T) {
 		wantMissing  []string
 	}{
 		{
-			name:         "bool true becomes presence flag",
+			name:         "bool true becomes explicit true",
 			flags:        map[string]any{"extended": true},
-			wantContains: []string{"--extended"},
+			wantContains: []string{"--extended", "true"},
 		},
 		{
 			name:         "bool false becomes explicit false",
 			flags:        map[string]any{"migrate-shared-disks": false},
-			wantContains: []string{"--migrate-shared-disks=false"},
+			wantContains: []string{"--migrate-shared-disks", "false"},
 		},
 		{
 			name:         "string true treated as bool",
 			flags:        map[string]any{"watch": "true"},
-			wantContains: []string{"--watch"},
+			wantContains: []string{"--watch", "true"},
 		},
 		{
 			name:         "string false treated as bool",
 			flags:        map[string]any{"watch": "false"},
-			wantContains: []string{"--watch=false"},
+			wantContains: []string{"--watch", "false"},
 		},
 		{
 			name:         "string value",
@@ -278,7 +278,7 @@ func TestAppendNormalizedFlags(t *testing.T) {
 		{
 			name:         "underscores converted to hyphens",
 			flags:        map[string]any{"migrate_shared_disks": false},
-			wantContains: []string{"--migrate-shared-disks=false"},
+			wantContains: []string{"--migrate-shared-disks", "false"},
 			wantMissing:  []string{"migrate_shared_disks"},
 		},
 		{

--- a/pkg/util/flags/explicit_bool.go
+++ b/pkg/util/flags/explicit_bool.go
@@ -1,0 +1,54 @@
+package flags
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+// ExplicitBool implements pflag.Value for boolean flags that require an
+// explicit value argument (e.g. --flag true / --flag false) instead of
+// Cobra's default presence-based semantics (--flag / --flag=false).
+//
+// Unlike standard BoolVar, this type does NOT implement IsBoolFlag()
+// returning true, so pflag always consumes the next argument as the value.
+type ExplicitBool struct {
+	value *bool
+}
+
+func (b *ExplicitBool) String() string {
+	if b.value == nil {
+		return "false"
+	}
+	return fmt.Sprintf("%t", *b.value)
+}
+
+func (b *ExplicitBool) Set(s string) error {
+	switch strings.ToLower(s) {
+	case "true", "1", "yes":
+		*b.value = true
+	case "false", "0", "no":
+		*b.value = false
+	default:
+		return fmt.Errorf("invalid boolean value %q (use true/false)", s)
+	}
+	return nil
+}
+
+func (b *ExplicitBool) Type() string {
+	return "bool"
+}
+
+// IsBoolFlag returns false so pflag consumes the next token as a value,
+// enabling --flag true and --flag false (space-separated).
+func (b *ExplicitBool) IsBoolFlag() bool {
+	return false
+}
+
+// ExplicitBoolVar registers a boolean flag that requires an explicit value.
+// Usage: flags.ExplicitBoolVar(cmd.Flags(), &myVar, "flag-name", true, "description")
+func ExplicitBoolVar(fs *pflag.FlagSet, p *bool, name string, value bool, usage string) {
+	*p = value
+	fs.Var(&ExplicitBool{value: p}, name, usage)
+}

--- a/pkg/util/flags/explicit_bool_test.go
+++ b/pkg/util/flags/explicit_bool_test.go
@@ -1,0 +1,155 @@
+package flags
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+func TestExplicitBool_Set(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    bool
+		wantErr bool
+	}{
+		{"true", true, false},
+		{"false", false, false},
+		{"True", true, false},
+		{"False", false, false},
+		{"TRUE", true, false},
+		{"FALSE", false, false},
+		{"1", true, false},
+		{"0", false, false},
+		{"yes", true, false},
+		{"no", false, false},
+		{"Yes", true, false},
+		{"No", false, false},
+		{"invalid", false, true},
+		{"", false, true},
+		{"maybe", false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			var val bool
+			b := &ExplicitBool{value: &val}
+			err := b.Set(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Set(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if err == nil && val != tt.want {
+				t.Errorf("Set(%q) = %v, want %v", tt.input, val, tt.want)
+			}
+		})
+	}
+}
+
+func TestExplicitBool_String(t *testing.T) {
+	val := true
+	b := &ExplicitBool{value: &val}
+	if got := b.String(); got != "true" {
+		t.Errorf("String() = %q, want %q", got, "true")
+	}
+
+	val = false
+	if got := b.String(); got != "false" {
+		t.Errorf("String() = %q, want %q", got, "false")
+	}
+}
+
+func TestExplicitBool_StringNil(t *testing.T) {
+	b := &ExplicitBool{}
+	if got := b.String(); got != "false" {
+		t.Errorf("String() with nil value = %q, want %q", got, "false")
+	}
+}
+
+func TestExplicitBool_Type(t *testing.T) {
+	b := &ExplicitBool{}
+	if got := b.Type(); got != "bool" {
+		t.Errorf("Type() = %q, want %q", got, "bool")
+	}
+}
+
+func TestExplicitBool_IsBoolFlag(t *testing.T) {
+	b := &ExplicitBool{}
+	if b.IsBoolFlag() {
+		t.Error("IsBoolFlag() = true, want false")
+	}
+}
+
+func TestExplicitBoolVar(t *testing.T) {
+	var val bool
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	ExplicitBoolVar(fs, &val, "my-flag", true, "test flag")
+
+	if val != true {
+		t.Errorf("default value = %v, want true", val)
+	}
+
+	if err := fs.Parse([]string{"--my-flag", "false"}); err != nil {
+		t.Fatalf("Parse(--my-flag false) error: %v", err)
+	}
+	if val != false {
+		t.Errorf("after --my-flag false: val = %v, want false", val)
+	}
+}
+
+func TestExplicitBoolVar_DefaultFalse(t *testing.T) {
+	var val bool
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	ExplicitBoolVar(fs, &val, "my-flag", false, "test flag")
+
+	if val != false {
+		t.Errorf("default value = %v, want false", val)
+	}
+
+	if err := fs.Parse([]string{"--my-flag", "true"}); err != nil {
+		t.Fatalf("Parse(--my-flag true) error: %v", err)
+	}
+	if val != true {
+		t.Errorf("after --my-flag true: val = %v, want true", val)
+	}
+}
+
+func TestExplicitBoolVar_EqualsSyntax(t *testing.T) {
+	var val bool
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	ExplicitBoolVar(fs, &val, "my-flag", true, "test flag")
+
+	if err := fs.Parse([]string{"--my-flag=false"}); err != nil {
+		t.Fatalf("Parse(--my-flag=false) error: %v", err)
+	}
+	if val != false {
+		t.Errorf("after --my-flag=false: val = %v, want false", val)
+	}
+}
+
+func TestExplicitBoolVar_Changed(t *testing.T) {
+	var val bool
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	ExplicitBoolVar(fs, &val, "my-flag", false, "test flag")
+
+	if fs.Changed("my-flag") {
+		t.Error("flag should not be marked as changed before parsing")
+	}
+
+	if err := fs.Parse([]string{"--my-flag", "true"}); err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	if !fs.Changed("my-flag") {
+		t.Error("flag should be marked as changed after parsing")
+	}
+}
+
+func TestExplicitBoolVar_NoValueErrors(t *testing.T) {
+	var val bool
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	ExplicitBoolVar(fs, &val, "my-flag", false, "test flag")
+
+	err := fs.Parse([]string{"--my-flag"})
+	if err == nil {
+		t.Error("Parse(--my-flag) without value should error")
+	}
+}


### PR DESCRIPTION
…flags

Cobra's BoolVar treats `--flag false` as a positional argument, so users had to write the non-intuitive `--flag=false` form. This adds an ExplicitBool flag type that consumes the next token as a value, enabling `--flag true` and `--flag false` (space-separated). Migrated 21 flag registrations across create plan (6), patch plan (14), patch provider (3), and help (1). Presence-only flags (--watch, --all, --dry-run, etc.) are unchanged.
Also updates the MCP normalization layer, help schema generator tests, inline Cobra examples, and guide documentation.
BREAKING CHANGE: boolean toggle flags (--preserve-static-ips, --migrate-shared-disks, --run-preflight-inspection, and others on create/patch commands) now require an explicit value argument. Use `--flag true` or `--flag false` instead of bare `--flag`. Fixes: #243

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Boolean command flags now require explicit true/false values (e.g., `--preserve-static-ips true` or `--preserve-static-ips false`) for clearer intent and consistent behavior across all commands.

* **Documentation**
  * Updated all command examples and guides to demonstrate the new explicit boolean flag syntax for plan creation, patching, and provider management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->