### PR TITLE
mcp-bools

### DIFF
--- a/pkg/mcp/tools/mtv_read.go
+++ b/pkg/mcp/tools/mtv_read.go
@@ -331,7 +331,7 @@ func buildArgs(cmdPath string, flags map[string]any) []string {
 
 // appendNormalizedFlags appends flags from a map[string]any to the args slice.
 // It handles different value types:
-//   - bool true/false: passes --flag true or --flag false (space-separated)
+//   - bool true/false: passes --flag=true or --flag=false (equals form, safe for both BoolVar and ExplicitBool)
 //   - string "true"/"false": treated as boolean
 //   - string/number: converted to string form
 //
@@ -357,15 +357,15 @@ func appendNormalizedFlags(args []string, flags map[string]any, skipFlags map[st
 		switch v := value.(type) {
 		case bool:
 			if v {
-				args = append(args, prefix+name, "true")
+				args = append(args, prefix+name+"=true")
 			} else {
-				args = append(args, prefix+name, "false")
+				args = append(args, prefix+name+"=false")
 			}
 		case string:
 			if v == "true" {
-				args = append(args, prefix+name, "true")
+				args = append(args, prefix+name+"=true")
 			} else if v == "false" {
-				args = append(args, prefix+name, "false")
+				args = append(args, prefix+name+"=false")
 			} else if v != "" {
 				args = append(args, prefix+name, v)
 			}

--- a/pkg/mcp/tools/mtv_read_test.go
+++ b/pkg/mcp/tools/mtv_read_test.go
@@ -217,24 +217,24 @@ func TestAppendNormalizedFlags(t *testing.T) {
 		wantMissing  []string
 	}{
 		{
-			name:         "bool true becomes explicit true",
+			name:         "bool true becomes equals true",
 			flags:        map[string]any{"extended": true},
-			wantContains: []string{"--extended", "true"},
+			wantContains: []string{"--extended=true"},
 		},
 		{
-			name:         "bool false becomes explicit false",
+			name:         "bool false becomes equals false",
 			flags:        map[string]any{"migrate-shared-disks": false},
-			wantContains: []string{"--migrate-shared-disks", "false"},
+			wantContains: []string{"--migrate-shared-disks=false"},
 		},
 		{
 			name:         "string true treated as bool",
 			flags:        map[string]any{"watch": "true"},
-			wantContains: []string{"--watch", "true"},
+			wantContains: []string{"--watch=true"},
 		},
 		{
 			name:         "string false treated as bool",
 			flags:        map[string]any{"watch": "false"},
-			wantContains: []string{"--watch", "false"},
+			wantContains: []string{"--watch=false"},
 		},
 		{
 			name:         "string value",
@@ -278,7 +278,7 @@ func TestAppendNormalizedFlags(t *testing.T) {
 		{
 			name:         "underscores converted to hyphens",
 			flags:        map[string]any{"migrate_shared_disks": false},
-			wantContains: []string{"--migrate-shared-disks", "false"},
+			wantContains: []string{"--migrate-shared-disks=false"},
 			wantMissing:  []string{"migrate_shared_disks"},
 		},
 		{

--- a/pkg/mcp/tools/mtv_write_test.go
+++ b/pkg/mcp/tools/mtv_write_test.go
@@ -85,7 +85,7 @@ func TestBuildWriteArgs(t *testing.T) {
 				"url":                        "https://vcenter.example.com",
 				"provider-insecure-skip-tls": true,
 			},
-			wantContains: []string{"create", "provider", "--name", "my-provider", "--type", "vsphere", "--url", "--provider-insecure-skip-tls"},
+			wantContains: []string{"create", "provider", "--name", "my-provider", "--type", "vsphere", "--url", "--provider-insecure-skip-tls=true"},
 		},
 		{
 			name:         "does not auto-add output format",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized boolean flag formatting to use equals notation (e.g., `--flag=true`) instead of space-separated format for consistent command-line argument output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->