### PR TITLE
chaning feature_windows_wait_for_reboot to true

### DIFF
--- a/pkg/cmd/settings/types.go
+++ b/pkg/cmd/settings/types.go
@@ -213,7 +213,7 @@ var SupportedSettings = map[string]SettingDefinition{
 	"feature_windows_wait_for_reboot": {
 		Name:        "feature_windows_wait_for_reboot",
 		Type:        TypeBool,
-		Default:     false,
+		Default:     true,
 		Description: "Enable Windows reboot wait during guest conversion",
 		Category:    CategoryFeature,
 	},


### PR DESCRIPTION
changing feature_windows_wait_for_reboot to true in type.go

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default behavior for Windows reboot waiting to be enabled by default, changing the system's default handling of reboot scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->