### PR TITLE
max-log-lines-fix

### DIFF
--- a/cmd/describe/plan.go
+++ b/cmd/describe/plan.go
@@ -96,8 +96,8 @@ Use --diagnostics to include pod logs, events, and configuration context.`,
 	cmd.Flags().StringVar(&vmName, "vm", "", "VM name to describe (switches to VM description mode)")
 	cmd.Flags().BoolVarP(&watch, "watch", "w", false, "Watch VM status with live updates (only when --vm is used)")
 	cmd.Flags().BoolVarP(&withDiagnostics, "diagnostics", "D", false, "Include diagnostics (pod logs, events, configuration context)")
-	cmd.Flags().IntVar(&logLines, "scan-log-lines", 500, "Number of log lines to scan for diagnostics")
-	cmd.Flags().IntVar(&showLines, "show-log-lines", 10, "Number of log lines to display in diagnostics output")
+	cmd.Flags().IntVar(&logLines, "scan-log-lines", 500, "Number of log lines to scan for diagnostics (max 10000)")
+	cmd.Flags().IntVar(&showLines, "show-log-lines", 10, "Number of log lines to display in diagnostics output (max 500)")
 	cmd.Flags().VarP(outputFormatFlag, "output", "o", flags.OutputFormatHelp)
 
 	_ = cmd.RegisterFlagCompletionFunc("name", completion.PlanNameCompletion(kubeConfigFlags))

--- a/pkg/cmd/describe/plan/diagnostics/gather.go
+++ b/pkg/cmd/describe/plan/diagnostics/gather.go
@@ -24,6 +24,12 @@ func GatherDiagnostics(ctx context.Context, configFlags *genericclioptions.Confi
 	if showLines <= 0 {
 		showLines = defaultShowLines
 	}
+	if logLines > MaxLogTailLines {
+		logLines = MaxLogTailLines
+	}
+	if showLines > MaxShowLines {
+		showLines = MaxShowLines
+	}
 
 	planUID := string(plan.GetUID())
 	planName := plan.GetName()
@@ -39,12 +45,13 @@ func GatherDiagnostics(ctx context.Context, configFlags *genericclioptions.Confi
 	localTarget := isLocalTarget(ctx, dynClient, plan)
 
 	report := &DiagnosticsReport{
-		PlanName:      planName,
-		PlanUID:       planUID,
-		MigrationName: migrationName,
-		MigrationUID:  migrationUID,
-		TargetNS:      targetNS,
-		RemoteTarget:  !localTarget,
+		PlanName:           planName,
+		PlanUID:            planUID,
+		MigrationName:      migrationName,
+		MigrationUID:       migrationUID,
+		TargetNS:           targetNS,
+		RemoteTarget:       !localTarget,
+		RequestedShowLines: showLines,
 	}
 
 	// Config context

--- a/pkg/cmd/describe/plan/diagnostics/pods.go
+++ b/pkg/cmd/describe/plan/diagnostics/pods.go
@@ -13,6 +13,12 @@ import (
 const defaultLogTailLines = 500
 const defaultShowLines = 10
 
+// MaxLogTailLines is the maximum number of log lines that can be scanned per container.
+const MaxLogTailLines = 10000
+
+// MaxShowLines is the maximum number of log lines that can be displayed per container.
+const MaxShowLines = 500
+
 // CollectPodDiagnostics lists pods matching the plan/migration labels and collects logs.
 func CollectPodDiagnostics(ctx context.Context, clientset *kubernetes.Clientset, namespace, planUID, migrationUID, vmID string, logLines, showLines int) []PodDiagnostics {
 	selector := fmt.Sprintf("plan=%s,migration=%s", planUID, migrationUID)

--- a/pkg/cmd/describe/plan/diagnostics/render.go
+++ b/pkg/cmd/describe/plan/diagnostics/render.go
@@ -32,18 +32,18 @@ func Render(b *describe.Builder, report *DiagnosticsReport) {
 	// Per-VM diagnostics
 	for i := range report.VMs {
 		vm := &report.VMs[i]
-		renderVM(b, vm)
+		renderVM(b, vm, report.RequestedShowLines)
 	}
 
 	// Controller logs
 	if report.ControllerLogs != nil {
 		b.SubSection("Controller Logs")
-		renderControllerLogs(b, report.ControllerLogs)
+		renderControllerLogs(b, report.ControllerLogs, report.RequestedShowLines)
 		b.EndSubSection()
 	}
 }
 
-func renderVM(b *describe.Builder, vm *VMDiagnostics) {
+func renderVM(b *describe.Builder, vm *VMDiagnostics, requestedShowLines int) {
 	title := fmt.Sprintf("VM: %s (%s)", vm.Name, vm.ID)
 	b.SubSection(title)
 
@@ -76,7 +76,7 @@ func renderVM(b *describe.Builder, vm *VMDiagnostics) {
 	// Pods
 	if len(vm.Pods) > 0 {
 		for i := range vm.Pods {
-			renderPod(b, vm.Pods[i])
+			renderPod(b, vm.Pods[i], requestedShowLines)
 		}
 	} else {
 		b.Text(output.Yellow("Pods"), "None found (may have been cleaned up)", "")
@@ -92,7 +92,7 @@ func renderVM(b *describe.Builder, vm *VMDiagnostics) {
 	b.EndSubSection()
 }
 
-func renderPod(b *describe.Builder, pod PodDiagnostics) {
+func renderPod(b *describe.Builder, pod PodDiagnostics, requestedShowLines int) {
 	phaseColor := output.Green
 	switch pod.Phase {
 	case "Failed", "Evicted":
@@ -113,17 +113,17 @@ func renderPod(b *describe.Builder, pod PodDiagnostics) {
 		lines = append(lines, fmt.Sprintf("V2V Stage: %s", stageDisplay))
 	}
 
-	lines = append(lines, formatLogAnalysis(pod.ErrorCount, pod.WarnCount, pod.ErrorLines, pod.LogTail)...)
+	lines = append(lines, formatLogAnalysis(pod.ErrorCount, pod.WarnCount, pod.ErrorLines, pod.LogTail, requestedShowLines)...)
 
 	b.Text(output.Green("Pod"), strings.Join(lines, "\n"), "")
 }
 
-func renderControllerLogs(b *describe.Builder, logs *ControllerLogAnalysis) {
-	lines := formatLogAnalysis(logs.ErrorCount, logs.WarnCount, logs.ErrorLines, logs.LogTail)
+func renderControllerLogs(b *describe.Builder, logs *ControllerLogAnalysis, requestedShowLines int) {
+	lines := formatLogAnalysis(logs.ErrorCount, logs.WarnCount, logs.ErrorLines, logs.LogTail, requestedShowLines)
 	b.Text("", strings.Join(lines, "\n"), "")
 }
 
-func formatLogAnalysis(errorCount, warnCount int, errorLines, logTail []string) []string {
+func formatLogAnalysis(errorCount, warnCount int, errorLines, logTail []string, requestedShowLines int) []string {
 	var lines []string
 
 	summary := fmt.Sprintf("%d errors, %d warnings", errorCount, warnCount)
@@ -137,7 +137,11 @@ func formatLogAnalysis(errorCount, warnCount int, errorLines, logTail []string) 
 
 	if errorCount > 0 && len(errorLines) > 0 {
 		lines = append(lines, "")
-		lines = append(lines, output.Red(fmt.Sprintf("Last %d error lines:", len(errorLines))))
+		if len(errorLines) < requestedShowLines {
+			lines = append(lines, output.Red(fmt.Sprintf("Last %d error lines (only %d found, %d requested):", len(errorLines), len(errorLines), requestedShowLines)))
+		} else {
+			lines = append(lines, output.Red(fmt.Sprintf("Last %d error lines:", len(errorLines))))
+		}
 		for _, l := range errorLines {
 			errLine := l
 			if len(errLine) > 200 {
@@ -149,7 +153,11 @@ func formatLogAnalysis(errorCount, warnCount int, errorLines, logTail []string) 
 
 	if len(logTail) > 0 {
 		lines = append(lines, "")
-		lines = append(lines, output.Cyan(fmt.Sprintf("Last %d log lines:", len(logTail))))
+		if len(logTail) < requestedShowLines {
+			lines = append(lines, output.Cyan(fmt.Sprintf("Last %d log lines (only %d found, %d requested):", len(logTail), len(logTail), requestedShowLines)))
+		} else {
+			lines = append(lines, output.Cyan(fmt.Sprintf("Last %d log lines:", len(logTail))))
+		}
 		for _, l := range logTail {
 			lines = append(lines, "  "+l)
 		}

--- a/pkg/cmd/describe/plan/diagnostics/types.go
+++ b/pkg/cmd/describe/plan/diagnostics/types.go
@@ -2,16 +2,17 @@ package diagnostics
 
 // DiagnosticsReport holds the complete diagnostics for a migration plan.
 type DiagnosticsReport struct {
-	PlanName       string
-	PlanUID        string
-	MigrationName  string
-	MigrationUID   string
-	TargetNS       string
-	CutoverTime    string
-	RemoteTarget   bool
-	VMs            []VMDiagnostics
-	Config         ConfigContext
-	ControllerLogs *ControllerLogAnalysis
+	PlanName           string
+	PlanUID            string
+	MigrationName      string
+	MigrationUID       string
+	TargetNS           string
+	CutoverTime        string
+	RemoteTarget       bool
+	RequestedShowLines int
+	VMs                []VMDiagnostics
+	Config             ConfigContext
+	ControllerLogs     *ControllerLogAnalysis
 }
 
 // ControllerLogAnalysis holds error-classified log analysis for the forklift-controller.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Diagnostics output now reflects the requested number of log lines more clearly, including when fewer lines are available than requested.
  * Log-line limits are now documented in the CLI help text, with clearer maximum values shown for scan and display options.

* **Bug Fixes**
  * Log-line requests are now capped to supported limits, helping prevent overly large diagnostics output.
  * Pod, VM, and controller log sections now use consistent line-count labeling in reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->