### PR TITLE
secrets-of-copy

### DIFF
--- a/guide/12-storage-array-offloading-and-optimization.md
+++ b/guide/12-storage-array-offloading-and-optimization.md
@@ -200,6 +200,8 @@ kubectl create secret generic storage-array-creds \
   -n openshift-mtv
 ```
 
+Forklift reads vSphere credentials from the source provider secret. The offload secret referenced by the `StorageMap` should contain storage-array credentials in the `STORAGE_*` format shown above. When you use inline `--offload-storage-*` flags, `kubectl-mtv` generates a secret with that same schema.
+
 ### Step 4: Verify Storage Array Compatibility
 
 Before configuring offloading, ensure your environment meets the requirements:
@@ -221,9 +223,6 @@ kubectl mtv create mapping storage --name offload-flashsystem \
   --source my-vsphere-provider \
   --target my-openshift-provider \
   --storage-pairs "production-ssd:flashsystem-gold;offloadPlugin=vsphere;offloadVendor=flashsystem" \
-  --offload-vsphere-username "svc-migration@vsphere.local" \
-  --offload-vsphere-password "VCenterPassword123" \
-  --offload-vsphere-url "https://vcenter.company.com/sdk" \
   --offload-storage-username "flashsystem-admin" \
   --offload-storage-password "FlashSystemPassword123" \
   --offload-storage-endpoint "https://flashsystem.company.com:7443"
@@ -239,9 +238,6 @@ kubectl mtv create mapping storage --name multi-vendor-offload \
   --target openshift-production \
   --storage-pairs "flashsystem-tier1:premium-flash;offloadPlugin=vsphere;offloadVendor=flashsystem,ontap-tier2:standard-ssd;offloadPlugin=vsphere;offloadVendor=ontap,pure-tier0:ultra-performance;offloadPlugin=vsphere;offloadVendor=pureFlashArray" \
   --default-offload-plugin vsphere \
-  --offload-vsphere-username vcenter-migration@company.local \
-  --offload-vsphere-password $(cat /secure/vcenter-pass) \
-  --offload-vsphere-url https://vcenter.prod.company.com \
   --offload-storage-username storage-admin \
   --offload-storage-password $(cat /secure/storage-pass) \
   --offload-storage-endpoint https://storage-mgmt.company.com
@@ -342,9 +338,6 @@ kubectl mtv create mapping storage --name ibm-flashsystem \
   --source vsphere-prod \
   --target openshift-target \
   --storage-pairs "flashsystem-gold:flashsystem-tier1;offloadPlugin=vsphere;offloadVendor=flashsystem;volumeMode=Block;accessMode=ReadWriteOnce" \
-  --offload-vsphere-username "svc-flashsystem@vsphere.local" \
-  --offload-vsphere-password "FlashSystemVCPassword" \
-  --offload-vsphere-url "https://vcenter.prod.company.com" \
   --offload-storage-username "flashsystem-admin" \
   --offload-storage-password "FlashSystemPassword" \
   --offload-storage-endpoint "https://flashsystem.company.com:7443"
@@ -365,9 +358,6 @@ kubectl mtv create mapping storage --name netapp-ontap \
   --source vsphere-prod \
   --target openshift-target \
   --storage-pairs "netapp-nfs:ontap-nas;offloadPlugin=vsphere;offloadVendor=ontap;volumeMode=Filesystem,netapp-san:ontap-san;offloadPlugin=vsphere;offloadVendor=ontap;volumeMode=Block" \
-  --offload-vsphere-username "ontap-svc@vsphere.local" \
-  --offload-vsphere-password "ONTAPVCPassword" \
-  --offload-vsphere-url "https://vcenter.company.com" \
   --offload-storage-username "ontap-admin" \
   --offload-storage-password "ONTAPPassword" \
   --offload-storage-endpoint "https://ontap-cluster.company.com"
@@ -388,9 +378,6 @@ kubectl mtv create mapping storage --name pure-flasharray \
   --source vsphere-prod \
   --target openshift-target \
   --storage-pairs "pure-vvol:pure-block-premium;offloadPlugin=vsphere;offloadVendor=pureFlashArray;volumeMode=Block;accessMode=ReadWriteOnce" \
-  --offload-vsphere-username "pure-svc@vsphere.local" \
-  --offload-vsphere-password "PureVCPassword" \
-  --offload-vsphere-url "https://vcenter.company.com" \
   --offload-storage-username "pureuser" \
   --offload-storage-password "PureStorageAPIKey" \
   --offload-storage-endpoint "https://pure-array.company.com" \
@@ -412,9 +399,6 @@ kubectl mtv create mapping storage --name dell-powermax \
   --source vsphere-enterprise \
   --target openshift-target \
   --storage-pairs "powermax-diamond:powermax-tier0;offloadPlugin=vsphere;offloadVendor=powermax;volumeMode=Block;accessMode=ReadWriteOnce" \
-  --offload-vsphere-username "powermax-svc@vsphere.local" \
-  --offload-vsphere-password "PowerMaxVCPassword" \
-  --offload-vsphere-url "https://vcenter.enterprise.com" \
   --offload-storage-username "powermax-admin" \
   --offload-storage-password "PowerMaxPassword" \
   --offload-storage-endpoint "https://powermax.company.com:8443"
@@ -430,19 +414,17 @@ kubectl mtv create mapping storage --name dell-powermax \
 
 ### Credential Management Best Practices
 
-Storage offloading requires credentials for both vSphere and storage arrays. Follow these security best practices:
+Storage offloading uses storage-array credentials from the offload secret and vSphere credentials from the source provider secret. Follow these security best practices:
 
 #### 1. Kubernetes Secrets for Credential Storage
 
 ```bash
 # Create separate secrets for each storage array
 kubectl create secret generic flashsystem-offload-creds \
-  --from-literal=vsphere-username=svc-migration@vsphere.local \
-  --from-literal=vsphere-password=VCenterPassword \
-  --from-literal=vsphere-url=https://vcenter.company.com \
-  --from-literal=storage-username=flashsystem-admin \
-  --from-literal=storage-password=FlashSystemPassword \
-  --from-literal=storage-endpoint=https://flashsystem.company.com:7443 \
+  --from-literal=STORAGE_HOSTNAME=https://flashsystem.company.com:7443 \
+  --from-literal=STORAGE_USERNAME=flashsystem-admin \
+  --from-literal=STORAGE_PASSWORD=FlashSystemPassword \
+  --from-literal=STORAGE_SKIP_SSL_VERIFICATION=false \
   -n konveyor-forklift
 
 # Reference the secret in storage mapping
@@ -647,7 +629,7 @@ curl -k -u username:password https://storage-array.company.com/api/auth
 
 # Update credentials in secret
 kubectl patch secret storage-offload-creds \
-  --patch '{"data":{"storage-password":"'"$(echo -n 'NewPassword' | base64)"'"}}'
+  --patch '{"data":{"STORAGE_PASSWORD":"'"$(echo -n 'NewPassword' | base64)"'"}}'
 
 # Restart affected pods to pick up new credentials
 kubectl delete pods -n konveyor-forklift -l app=forklift-controller

--- a/pkg/cmd/create/host/host.go
+++ b/pkg/cmd/create/host/host.go
@@ -387,7 +387,7 @@ func buildHostSecretObject(namespace, hostResourceName, username, password strin
 		secretData["insecureSkipVerify"] = []byte("true")
 	}
 	if cacert != "" {
-		secretData["cacert"] = []byte(cacert)
+		secretData["ca.crt"] = []byte(cacert)
 	}
 
 	meta := metav1.ObjectMeta{

--- a/pkg/cmd/create/host/host_test.go
+++ b/pkg/cmd/create/host/host_test.go
@@ -1,0 +1,14 @@
+package host
+
+import "testing"
+
+func TestBuildHostSecretObject_UsesStandardCACertKey(t *testing.T) {
+	secret := buildHostSecretObject("openshift-mtv", "esxi-host", "user", "pass", false, "cert-data", true)
+
+	if got := string(secret.Data["ca.crt"]); got != "cert-data" {
+		t.Fatalf("ca.crt = %q, want %q", got, "cert-data")
+	}
+	if _, found := secret.Data["cacert"]; found {
+		t.Fatal("unexpected legacy cacert key in host secret")
+	}
+}

--- a/pkg/cmd/create/mapping/mapping_test.go
+++ b/pkg/cmd/create/mapping/mapping_test.go
@@ -210,34 +210,31 @@ func TestValidateOffloadSecretFields_NoFieldsSet(t *testing.T) {
 	}
 }
 
-func TestValidateOffloadSecretFields_AllRequired(t *testing.T) {
+func TestValidateOffloadSecretFields_StorageFieldsRequired(t *testing.T) {
 	opts := StorageCreateOptions{
-		OffloadVSphereUsername: "user",
-		OffloadVSpherePassword: "pass",
-		OffloadVSphereURL:      "https://vcenter",
 		OffloadStorageUsername: "storuser",
 		OffloadStoragePassword: "storpass",
 		OffloadStorageEndpoint: "https://storage",
 	}
 	if err := validateOffloadSecretFields(opts); err != nil {
-		t.Errorf("expected nil for all required fields, got: %v", err)
+		t.Errorf("expected nil for required storage fields, got: %v", err)
 	}
 }
 
 func TestValidateOffloadSecretFields_PartialFields(t *testing.T) {
 	opts := StorageCreateOptions{
-		OffloadVSphereUsername: "user",
-		// Missing all other required fields
+		OffloadStorageUsername: "storuser",
+		// Missing the remaining storage fields.
 	}
 	err := validateOffloadSecretFields(opts)
 	if err == nil {
 		t.Error("expected error for partial fields")
 	}
-	if !strings.Contains(err.Error(), "--offload-vsphere-password") {
-		t.Errorf("expected missing password in error, got: %s", err.Error())
+	if !strings.Contains(err.Error(), "--offload-storage-password") {
+		t.Errorf("expected missing storage password in error, got: %s", err.Error())
 	}
-	if !strings.Contains(err.Error(), "--offload-storage-username") {
-		t.Errorf("expected missing storage username in error, got: %s", err.Error())
+	if !strings.Contains(err.Error(), "--offload-storage-endpoint") {
+		t.Errorf("expected missing storage endpoint in error, got: %s", err.Error())
 	}
 }
 
@@ -263,9 +260,6 @@ func TestValidateOffloadSecretFields_OnlyCACert(t *testing.T) {
 
 func TestValidateOffloadSecretFields_AllRequiredPlusOptional(t *testing.T) {
 	opts := StorageCreateOptions{
-		OffloadVSphereUsername: "user",
-		OffloadVSpherePassword: "pass",
-		OffloadVSphereURL:      "https://vcenter",
 		OffloadStorageUsername: "storuser",
 		OffloadStoragePassword: "storpass",
 		OffloadStorageEndpoint: "https://storage",

--- a/pkg/cmd/create/mapping/offload/offload.go
+++ b/pkg/cmd/create/mapping/offload/offload.go
@@ -46,29 +46,20 @@ func BuildSecret(namespace, baseName string, opts SecretOptions, dryRun bool) (*
 
 	secretData := map[string][]byte{}
 
-	if opts.VSphereUsername != "" {
-		secretData["user"] = []byte(opts.VSphereUsername)
-	}
-	if opts.VSpherePassword != "" {
-		secretData["password"] = []byte(opts.VSpherePassword)
-	}
-	if opts.VSphereURL != "" {
-		secretData["url"] = []byte(opts.VSphereURL)
-	}
 	if opts.StorageUsername != "" {
-		secretData["storageUser"] = []byte(opts.StorageUsername)
+		secretData["STORAGE_USERNAME"] = []byte(opts.StorageUsername)
 	}
 	if opts.StoragePassword != "" {
-		secretData["storagePassword"] = []byte(opts.StoragePassword)
+		secretData["STORAGE_PASSWORD"] = []byte(opts.StoragePassword)
 	}
 	if opts.StorageEndpoint != "" {
-		secretData["storageEndpoint"] = []byte(opts.StorageEndpoint)
+		secretData["STORAGE_HOSTNAME"] = []byte(opts.StorageEndpoint)
 	}
 	if opts.InsecureSkipTLS {
-		secretData["insecureSkipVerify"] = []byte("true")
+		secretData["STORAGE_SKIP_SSL_VERIFICATION"] = []byte("true")
 	}
 	if cacert != "" {
-		secretData["cacert"] = []byte(cacert)
+		secretData["ca.crt"] = []byte(cacert)
 	}
 
 	if len(secretData) == 0 {
@@ -132,21 +123,11 @@ func ValidateSecretFields(opts SecretOptions) error {
 		return nil // No validation needed if no fields provided
 	}
 
-	// If any offload fields are provided, validate required combinations
+	// If any offload fields are provided, validate the required storage credentials.
+	// Forklift reads vSphere credentials from the source provider secret rather than
+	// from the StorageMap offload secret.
 	var missingFields []string
 
-	// vSphere credentials are required
-	if opts.VSphereUsername == "" {
-		missingFields = append(missingFields, "--offload-vsphere-username")
-	}
-	if opts.VSpherePassword == "" {
-		missingFields = append(missingFields, "--offload-vsphere-password")
-	}
-	if opts.VSphereURL == "" {
-		missingFields = append(missingFields, "--offload-vsphere-url")
-	}
-
-	// Storage credentials are required
 	if opts.StorageUsername == "" {
 		missingFields = append(missingFields, "--offload-storage-username")
 	}

--- a/pkg/cmd/create/mapping/offload/offload_test.go
+++ b/pkg/cmd/create/mapping/offload/offload_test.go
@@ -1,0 +1,79 @@
+package offload
+
+import "testing"
+
+func TestBuildSecret_UsesForkliftStorageKeys(t *testing.T) {
+	opts := SecretOptions{
+		VSphereUsername: "ignored-user",
+		VSpherePassword: "ignored-pass",
+		VSphereURL:      "https://ignored-vcenter",
+		StorageUsername: "storage-user",
+		StoragePassword: "storage-pass",
+		StorageEndpoint: "https://storage.example.com",
+		CACert:          "test-ca-cert",
+		InsecureSkipTLS: true,
+	}
+
+	secret, err := BuildSecret("openshift-mtv", "example", opts, true)
+	if err != nil {
+		t.Fatalf("BuildSecret() error = %v", err)
+	}
+
+	if got := string(secret.Data["STORAGE_USERNAME"]); got != "storage-user" {
+		t.Fatalf("STORAGE_USERNAME = %q, want %q", got, "storage-user")
+	}
+	if got := string(secret.Data["STORAGE_PASSWORD"]); got != "storage-pass" {
+		t.Fatalf("STORAGE_PASSWORD = %q, want %q", got, "storage-pass")
+	}
+	if got := string(secret.Data["STORAGE_HOSTNAME"]); got != "https://storage.example.com" {
+		t.Fatalf("STORAGE_HOSTNAME = %q, want %q", got, "https://storage.example.com")
+	}
+	if got := string(secret.Data["STORAGE_SKIP_SSL_VERIFICATION"]); got != "true" {
+		t.Fatalf("STORAGE_SKIP_SSL_VERIFICATION = %q, want %q", got, "true")
+	}
+	if got := string(secret.Data["ca.crt"]); got != "test-ca-cert" {
+		t.Fatalf("ca.crt = %q, want %q", got, "test-ca-cert")
+	}
+
+	legacyKeys := []string{
+		"user",
+		"password",
+		"url",
+		"storageUser",
+		"storagePassword",
+		"storageEndpoint",
+		"insecureSkipVerify",
+		"cacert",
+	}
+	for _, key := range legacyKeys {
+		if _, found := secret.Data[key]; found {
+			t.Fatalf("unexpected legacy key %q found in generated secret", key)
+		}
+	}
+}
+
+func TestValidateSecretFields_AllowsStorageOnlyInlineCredentials(t *testing.T) {
+	opts := SecretOptions{
+		StorageUsername: "storage-user",
+		StoragePassword: "storage-pass",
+		StorageEndpoint: "https://storage.example.com",
+	}
+
+	if err := ValidateSecretFields(opts); err != nil {
+		t.Fatalf("ValidateSecretFields() error = %v, want nil", err)
+	}
+}
+
+func TestValidateSecretFields_RequiresStorageFields(t *testing.T) {
+	opts := SecretOptions{
+		VSphereUsername: "legacy-user",
+	}
+
+	err := ValidateSecretFields(opts)
+	if err == nil {
+		t.Fatal("ValidateSecretFields() error = nil, want missing storage fields")
+	}
+	if got := err.Error(); got == "" {
+		t.Fatal("ValidateSecretFields() returned an empty error")
+	}
+}

--- a/pkg/cmd/create/provider/ec2/secrets.go
+++ b/pkg/cmd/create/provider/ec2/secrets.go
@@ -25,7 +25,7 @@ func buildSecret(namespace, providerName, accessKeyID, secretAccessKey, url, cac
 		secretData["insecureSkipVerify"] = []byte("true")
 	}
 	if cacert != "" {
-		secretData["cacert"] = []byte(cacert)
+		secretData["ca.crt"] = []byte(cacert)
 	}
 
 	if targetAccessKeyID != "" {

--- a/pkg/cmd/create/provider/ec2/secrets_test.go
+++ b/pkg/cmd/create/provider/ec2/secrets_test.go
@@ -1,0 +1,14 @@
+package ec2
+
+import "testing"
+
+func TestBuildSecret_UsesStandardCACertKey(t *testing.T) {
+	secret := buildSecret("openshift-mtv", "source", "ak", "sk", "https://ec2", "cert-data", "us-east-1", false, "", "")
+
+	if got := string(secret.Data["ca.crt"]); got != "cert-data" {
+		t.Fatalf("ca.crt = %q, want %q", got, "cert-data")
+	}
+	if _, found := secret.Data["cacert"]; found {
+		t.Fatal("unexpected legacy cacert key in EC2 secret")
+	}
+}

--- a/pkg/cmd/create/provider/generic/secrets.go
+++ b/pkg/cmd/create/provider/generic/secrets.go
@@ -29,7 +29,7 @@ func buildSecret(namespace, providerName, user, password, url, cacert, token str
 	}
 
 	if cacert != "" {
-		secretData["cacert"] = []byte(cacert)
+		secretData["ca.crt"] = []byte(cacert)
 	}
 
 	if insecureSkipTLS {

--- a/pkg/cmd/create/provider/generic/secrets_test.go
+++ b/pkg/cmd/create/provider/generic/secrets_test.go
@@ -1,0 +1,14 @@
+package generic
+
+import "testing"
+
+func TestBuildSecret_UsesStandardCACertKey(t *testing.T) {
+	secret := buildSecret("openshift-mtv", "source", "user", "pass", "https://manager", "cert-data", "", false, "", "", "", "ovirt")
+
+	if got := string(secret.Data["ca.crt"]); got != "cert-data" {
+		t.Fatalf("ca.crt = %q, want %q", got, "cert-data")
+	}
+	if _, found := secret.Data["cacert"]; found {
+		t.Fatal("unexpected legacy cacert key in generic provider secret")
+	}
+}

--- a/pkg/cmd/create/provider/hyperv/secrets.go
+++ b/pkg/cmd/create/provider/hyperv/secrets.go
@@ -38,7 +38,7 @@ func buildSecret(namespace, providerName string, options providerutil.ProviderOp
 		secretData["insecureSkipVerify"] = []byte("true")
 	}
 	if options.CACert != "" {
-		secretData["cacert"] = []byte(options.CACert)
+		secretData["ca.crt"] = []byte(options.CACert)
 	}
 
 	return &corev1.Secret{

--- a/pkg/cmd/create/provider/hyperv/secrets_test.go
+++ b/pkg/cmd/create/provider/hyperv/secrets_test.go
@@ -1,0 +1,25 @@
+package hyperv
+
+import (
+	"testing"
+
+	"github.com/yaacov/kubectl-mtv/pkg/cmd/create/provider/providerutil"
+)
+
+func TestBuildSecret_UsesStandardCACertKey(t *testing.T) {
+	secret, err := buildSecret("openshift-mtv", "source", providerutil.ProviderOptions{
+		Username: "user",
+		Password: "pass",
+		CACert:   "cert-data",
+	})
+	if err != nil {
+		t.Fatalf("buildSecret() error = %v", err)
+	}
+
+	if got := string(secret.Data["ca.crt"]); got != "cert-data" {
+		t.Fatalf("ca.crt = %q, want %q", got, "cert-data")
+	}
+	if _, found := secret.Data["cacert"]; found {
+		t.Fatal("unexpected legacy cacert key in Hyper-V secret")
+	}
+}

--- a/pkg/cmd/create/provider/openshift/secrets.go
+++ b/pkg/cmd/create/provider/openshift/secrets.go
@@ -22,7 +22,7 @@ func buildSecret(namespace, providerName, url, token, cacert string, insecureSki
 		secretData["insecureSkipVerify"] = []byte("true")
 	}
 	if cacert != "" {
-		secretData["cacert"] = []byte(cacert)
+		secretData["ca.crt"] = []byte(cacert)
 	}
 
 	return &corev1.Secret{

--- a/pkg/cmd/create/provider/openshift/secrets_test.go
+++ b/pkg/cmd/create/provider/openshift/secrets_test.go
@@ -1,0 +1,14 @@
+package openshift
+
+import "testing"
+
+func TestBuildSecret_UsesStandardCACertKey(t *testing.T) {
+	secret := buildSecret("openshift-mtv", "target", "https://api.cluster", "token", "cert-data", false)
+
+	if got := string(secret.Data["ca.crt"]); got != "cert-data" {
+		t.Fatalf("ca.crt = %q, want %q", got, "cert-data")
+	}
+	if _, found := secret.Data["cacert"]; found {
+		t.Fatal("unexpected legacy cacert key in OpenShift secret")
+	}
+}

--- a/pkg/cmd/create/provider/openstack/secrets.go
+++ b/pkg/cmd/create/provider/openstack/secrets.go
@@ -29,7 +29,7 @@ func buildSecret(namespace, providerName, username, password, url, cacert, token
 	}
 
 	if cacert != "" {
-		secretData["cacert"] = []byte(cacert)
+		secretData["ca.crt"] = []byte(cacert)
 	}
 
 	if insecureSkipTLS {

--- a/pkg/cmd/create/provider/openstack/secrets_test.go
+++ b/pkg/cmd/create/provider/openstack/secrets_test.go
@@ -1,0 +1,14 @@
+package openstack
+
+import "testing"
+
+func TestBuildSecret_UsesStandardCACertKey(t *testing.T) {
+	secret := buildSecret("openshift-mtv", "source", "user", "pass", "https://keystone", "cert-data", "", false, "default", "demo", "regionOne")
+
+	if got := string(secret.Data["ca.crt"]); got != "cert-data" {
+		t.Fatalf("ca.crt = %q, want %q", got, "cert-data")
+	}
+	if _, found := secret.Data["cacert"]; found {
+		t.Fatal("unexpected legacy cacert key in OpenStack secret")
+	}
+}

--- a/pkg/cmd/create/provider/vsphere/secrets.go
+++ b/pkg/cmd/create/provider/vsphere/secrets.go
@@ -24,7 +24,7 @@ func buildSecret(namespace, providerName, user, password, url, cacert string, in
 		secretData["insecureSkipVerify"] = []byte("true")
 	}
 	if cacert != "" {
-		secretData["cacert"] = []byte(cacert)
+		secretData["ca.crt"] = []byte(cacert)
 	}
 
 	secret := &corev1.Secret{

--- a/pkg/cmd/create/provider/vsphere/secrets_test.go
+++ b/pkg/cmd/create/provider/vsphere/secrets_test.go
@@ -1,0 +1,14 @@
+package vsphere
+
+import "testing"
+
+func TestBuildSecret_UsesStandardCACertKey(t *testing.T) {
+	secret := buildSecret("openshift-mtv", "source", "user", "pass", "https://vcenter", "cert-data", false)
+
+	if got := string(secret.Data["ca.crt"]); got != "cert-data" {
+		t.Fatalf("ca.crt = %q, want %q", got, "cert-data")
+	}
+	if _, found := secret.Data["cacert"]; found {
+		t.Fatal("unexpected legacy cacert key in vSphere secret")
+	}
+}

--- a/pkg/cmd/patch/provider/patch.go
+++ b/pkg/cmd/patch/provider/patch.go
@@ -471,7 +471,8 @@ func updateSecretCredentials(configFlags *genericclioptions.ConfigFlags, secret 
 
 	// Update CA certificate for all types (if applicable)
 	if opts.CACert != "" {
-		secret.Data["cacert"] = []byte(opts.CACert)
+		secret.Data["ca.crt"] = []byte(opts.CACert)
+		delete(secret.Data, "cacert")
 		klog.V(2).Infof("Updated CA certificate")
 		updated = true
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized CA certificate storage in created and updated secrets so certificates now use the expected `ca.crt` field.
  * Updated offload credential handling to rely on storage credentials consistently, including validation and secret generation.

* **Documentation**
  * Clarified secret and credential setup examples, including the correct secret key names and updated troubleshooting steps.

* **Tests**
  * Added coverage to verify the new certificate key naming and storage-only offload credential behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->