### PR TITLE
Add csiVolumeImport offload plugin support

### DIFF
--- a/cmd/create/mapping.go
+++ b/cmd/create/mapping.go
@@ -153,7 +153,13 @@ plugin configuration for optimized data transfer.`,
   kubectl-mtv create mapping storage --name my-storage-map \
     --source vsphere-prod \
     --target host \
-    --storage-pairs "datastore1:ocs-storagecluster-ceph-rbd;offloadPlugin=vsphere;offloadVendor=ontap"`,
+    --storage-pairs "datastore1:ocs-storagecluster-ceph-rbd;offloadPlugin=vsphere;offloadVendor=ontap"
+
+  # Create a storage mapping with CSI volume import offload
+  kubectl-mtv create mapping storage --name my-csi-map \
+    --source vsphere-prod \
+    --target host \
+    --storage-pairs "datastore1:hpe-sc;offloadPlugin=csiVolumeImport;offloadVendor=primera3par"`,
 		Args:         cobra.MaximumNArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -214,10 +220,10 @@ plugin configuration for optimized data transfer.`,
 	cmd.Flags().StringVarP(&name, "name", "M", "", "Storage mapping name")
 	cmd.Flags().StringVarP(&sourceProvider, "source", "S", "", "Source provider name")
 	cmd.Flags().StringVarP(&targetProvider, "target", "T", "", "Target provider name")
-	cmd.Flags().StringVar(&storagePairs, "storage-pairs", "", "Storage mapping pairs in format 'source:storage-class[;volumeMode=Block|Filesystem][;accessMode=ReadWriteOnce|ReadWriteMany|ReadOnlyMany][;offloadPlugin=vsphere][;offloadSecret=secret-name][;offloadVendor=vantara|ontap|...]' (comma-separated pairs, semicolon-separated parameters)")
+	cmd.Flags().StringVar(&storagePairs, "storage-pairs", "", "Storage mapping pairs in format 'source:storage-class[;volumeMode=Block|Filesystem][;accessMode=ReadWriteOnce|ReadWriteMany|ReadOnlyMany][;offloadPlugin=vsphere|csiVolumeImport][;offloadSecret=secret-name][;offloadVendor=vantara|ontap|...]' (comma-separated pairs, semicolon-separated parameters)")
 	cmd.Flags().StringVar(&defaultVolumeMode, "default-volume-mode", "", "Default volume mode for all storage pairs (Filesystem|Block)")
 	cmd.Flags().StringVar(&defaultAccessMode, "default-access-mode", "", "Default access mode for all storage pairs (ReadWriteOnce|ReadWriteMany|ReadOnlyMany)")
-	cmd.Flags().StringVar(&defaultOffloadPlugin, "default-offload-plugin", "", "Default offload plugin type for all storage pairs (vsphere)")
+	cmd.Flags().StringVar(&defaultOffloadPlugin, "default-offload-plugin", "", flags.OffloadPluginHelp)
 	cmd.Flags().StringVar(&defaultOffloadSecret, "default-offload-secret", "", "Existing offload secret name to use (creates new secret if not provided and offload credentials given)")
 	cmd.Flags().StringVar(&defaultOffloadVendor, "default-offload-vendor", "", flags.OffloadVendorHelp)
 	cmd.Flags().StringVar(&defaultOffloadMigrationHosts, "default-offload-migration-hosts", "", "Default dedicated ESXi host IDs for XCOPY migrations (+-separated, e.g. host-10+host-11)")
@@ -252,7 +258,7 @@ plugin configuration for optimized data transfer.`,
 
 	// Add completion for offload plugin flag
 	if err := cmd.RegisterFlagCompletionFunc("default-offload-plugin", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"vsphere"}, cobra.ShellCompDirectiveNoFileComp
+		return flags.OffloadPlugins, cobra.ShellCompDirectiveNoFileComp
 	}); err != nil {
 		panic(err)
 	}

--- a/cmd/create/plan.go
+++ b/cmd/create/plan.go
@@ -136,7 +136,8 @@ Mapping Pair Formats (when overriding auto-generated mappings):
     source:storageclass               - Basic mapping
     source:sc;volumeMode=Block        - With volume mode (Filesystem|Block)
     source:sc;accessMode=ReadWriteMany - With access mode
-    source:sc;offloadPlugin=vsphere;offloadVendor=ontap - Storage offload
+    source:sc;offloadPlugin=vsphere;offloadVendor=ontap - Storage offload (XCOPY)
+    source:sc;offloadPlugin=csiVolumeImport;offloadVendor=primera3par - CSI import offload
     Options are semicolon-separated and can be combined:
     Example: "ds1:fast-ssd,ds2:economy;volumeMode=Block;accessMode=ReadWriteOnce"
 
@@ -553,7 +554,7 @@ Affinity Syntax (KARL):
 	// Storage enhancement flags
 	cmd.Flags().StringVar(&defaultVolumeMode, "default-volume-mode", "", "Default volume mode for storage pairs (Filesystem|Block)")
 	cmd.Flags().StringVar(&defaultAccessMode, "default-access-mode", "", "Default access mode for storage pairs (ReadWriteOnce|ReadWriteMany|ReadOnlyMany)")
-	cmd.Flags().StringVar(&defaultOffloadPlugin, "default-offload-plugin", "", "Default offload plugin type for storage pairs (vsphere)")
+	cmd.Flags().StringVar(&defaultOffloadPlugin, "default-offload-plugin", "", flags.OffloadPluginHelp)
 	cmd.Flags().StringVar(&defaultOffloadSecret, "default-offload-secret", "", "Existing offload secret name to use for storage offload")
 	cmd.Flags().StringVar(&defaultOffloadVendor, "default-offload-vendor", "", flags.OffloadVendorHelp)
 	cmd.Flags().StringVar(&defaultOffloadMigrationHosts, "default-offload-migration-hosts", "", "Default dedicated ESXi host IDs for XCOPY migrations (+-separated, e.g. host-10+host-11)")
@@ -642,7 +643,7 @@ Affinity Syntax (KARL):
 	}
 
 	if err := cmd.RegisterFlagCompletionFunc("default-offload-plugin", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"vsphere"}, cobra.ShellCompDirectiveNoFileComp
+		return flags.OffloadPlugins, cobra.ShellCompDirectiveNoFileComp
 	}); err != nil {
 		panic(err)
 	}

--- a/cmd/patch/mapping.go
+++ b/cmd/patch/mapping.go
@@ -122,12 +122,12 @@ func newPatchStorageMappingCmd(kubeConfigFlags *genericclioptions.ConfigFlags, g
 
 	cmd.Flags().StringVarP(&name, "name", "M", "", "Storage mapping name")
 	flags.MarkRequiredForMCP(cmd, "name")
-	cmd.Flags().StringVar(&addPairs, "add-pairs", "", "Storage pairs to add in format 'source:storage-class[;volumeMode=Block|Filesystem][;accessMode=ReadWriteOnce|ReadWriteMany|ReadOnlyMany][;offloadPlugin=vsphere][;offloadSecret=secret-name][;offloadVendor=vantara|ontap|...]' (comma-separated pairs, semicolon-separated parameters)")
-	cmd.Flags().StringVar(&updatePairs, "update-pairs", "", "Storage pairs to update in format 'source:storage-class[;volumeMode=Block|Filesystem][;accessMode=ReadWriteOnce|ReadWriteMany|ReadOnlyMany][;offloadPlugin=vsphere][;offloadSecret=secret-name][;offloadVendor=vantara|ontap|...]' (comma-separated pairs, semicolon-separated parameters)")
+	cmd.Flags().StringVar(&addPairs, "add-pairs", "", "Storage pairs to add in format 'source:storage-class[;volumeMode=Block|Filesystem][;accessMode=ReadWriteOnce|ReadWriteMany|ReadOnlyMany][;offloadPlugin=vsphere|csiVolumeImport][;offloadSecret=secret-name][;offloadVendor=vantara|ontap|...]' (comma-separated pairs, semicolon-separated parameters)")
+	cmd.Flags().StringVar(&updatePairs, "update-pairs", "", "Storage pairs to update in format 'source:storage-class[;volumeMode=Block|Filesystem][;accessMode=ReadWriteOnce|ReadWriteMany|ReadOnlyMany][;offloadPlugin=vsphere|csiVolumeImport][;offloadSecret=secret-name][;offloadVendor=vantara|ontap|...]' (comma-separated pairs, semicolon-separated parameters)")
 	cmd.Flags().StringVar(&removePairs, "remove-pairs", "", "Source storage names to remove from mapping (comma-separated)")
 	cmd.Flags().StringVar(&defaultVolumeMode, "default-volume-mode", "", "Default volume mode for new/updated storage pairs (Filesystem|Block)")
 	cmd.Flags().StringVar(&defaultAccessMode, "default-access-mode", "", "Default access mode for new/updated storage pairs (ReadWriteOnce|ReadWriteMany|ReadOnlyMany)")
-	cmd.Flags().StringVar(&defaultOffloadPlugin, "default-offload-plugin", "", "Default offload plugin type for new/updated storage pairs (vsphere)")
+	cmd.Flags().StringVar(&defaultOffloadPlugin, "default-offload-plugin", "", flags.OffloadPluginHelp)
 	cmd.Flags().StringVar(&defaultOffloadSecret, "default-offload-secret", "", "Default offload plugin secret name for new/updated storage pairs")
 	cmd.Flags().StringVar(&defaultOffloadVendor, "default-offload-vendor", "", flags.OffloadVendorHelp)
 	cmd.Flags().StringVar(&defaultOffloadMigrationHosts, "default-offload-migration-hosts", "", "Default dedicated ESXi host IDs for XCOPY migrations (+-separated, e.g. host-10+host-11)")
@@ -148,7 +148,7 @@ func newPatchStorageMappingCmd(kubeConfigFlags *genericclioptions.ConfigFlags, g
 
 	// Add completion for offload plugin flag
 	if err := cmd.RegisterFlagCompletionFunc("default-offload-plugin", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"vsphere"}, cobra.ShellCompDirectiveNoFileComp
+		return flags.OffloadPlugins, cobra.ShellCompDirectiveNoFileComp
 	}); err != nil {
 		panic(err)
 	}

--- a/pkg/cmd/create/mapping/mapping_test.go
+++ b/pkg/cmd/create/mapping/mapping_test.go
@@ -167,8 +167,10 @@ func TestValidateAccessMode_Invalid(t *testing.T) {
 // --- validateOffloadPlugin ---
 
 func TestValidateOffloadPlugin_Valid(t *testing.T) {
-	if err := validateOffloadPlugin("vsphere"); err != nil {
-		t.Errorf("validateOffloadPlugin(vsphere) = error %v", err)
+	for _, plugin := range []string{"vsphere", "csiVolumeImport"} {
+		if err := validateOffloadPlugin(plugin); err != nil {
+			t.Errorf("validateOffloadPlugin(%s) = error %v", plugin, err)
+		}
 	}
 }
 

--- a/pkg/cmd/create/mapping/storage.go
+++ b/pkg/cmd/create/mapping/storage.go
@@ -42,12 +42,7 @@ func validateAccessMode(mode string) error {
 
 // validateOffloadPlugin validates offload plugin values
 func validateOffloadPlugin(plugin string) error {
-	switch plugin {
-	case "vsphere":
-		return nil
-	default:
-		return fmt.Errorf("must be one of: vsphere")
-	}
+	return flags.ValidateOffloadPlugin(plugin)
 }
 
 // validateOffloadVendor validates offload vendor values
@@ -229,8 +224,13 @@ func parseStoragePairsInternal(pairStr, defaultNamespace string, configFlags *ge
 						}
 					}
 					offloadPluginConfig.VSphereXcopyPluginConfig = xcopyConfig
+				case "csiVolumeImport":
+					offloadPluginConfig.CsiVolumeImport = &forkliftv1beta1.CsiVolumeImport{
+						SecretRef:            offloadSecret,
+						StorageVendorProduct: forkliftv1beta1.StorageVendorProduct(offloadVendor),
+					}
 				default:
-					return nil, fmt.Errorf("unknown offload plugin '%s' for storage pair '%s': supported plugins are: vsphere", offloadPlugin, sourceName)
+					return nil, fmt.Errorf("unknown offload plugin '%s' for storage pair '%s': supported plugins are: vsphere, csiVolumeImport", offloadPlugin, sourceName)
 				}
 
 				pair.OffloadPlugin = offloadPluginConfig

--- a/pkg/cmd/create/plan/storage/mapper/interfaces.go
+++ b/pkg/cmd/create/plan/storage/mapper/interfaces.go
@@ -59,6 +59,13 @@ func ApplyOffloadToPairs(pairs []forkliftv1beta1.StoragePair, opts StorageMappin
 				pairs[i].OffloadPlugin = &forkliftv1beta1.OffloadPlugin{
 					VSphereXcopyPluginConfig: xcopyConfig,
 				}
+			case "csiVolumeImport":
+				pairs[i].OffloadPlugin = &forkliftv1beta1.OffloadPlugin{
+					CsiVolumeImport: &forkliftv1beta1.CsiVolumeImport{
+						SecretRef:            opts.DefaultOffloadSecret,
+						StorageVendorProduct: forkliftv1beta1.StorageVendorProduct(opts.DefaultOffloadVendor),
+					},
+				}
 			}
 		}
 	}

--- a/pkg/cmd/help/topics.go
+++ b/pkg/cmd/help/topics.go
@@ -257,9 +257,9 @@ Examples
 	},
 	{
 		Name:  "offload",
-		Short: "Storage copy-offload (XCOPY) configuration reference",
-		Content: `Storage Copy-Offload (XCOPY) Reference
-======================================
+		Short: "Storage copy-offload configuration reference",
+		Content: `Storage Copy-Offload Reference
+==============================
 
 Copy-offload delegates disk copying to the storage array instead of streaming
 data through the cluster network, dramatically improving migration speed.
@@ -267,11 +267,25 @@ data through the cluster network, dramatically improving migration speed.
 Prerequisites:
   kubectl mtv settings set --setting feature_copy_offload --value true
 
-How It Works:
+Offload Plugin Types
+--------------------
+  vsphere          Uses VAAI/XCOPY via a VolumePopulator pod to clone disks
+                   directly on the storage array.
+  csiVolumeImport  Uses the CSI driver's native import capability to migrate
+                   VVol/RDM disks. No populator pod or service account is
+                   launched — the controller creates a PVC with import
+                   annotations and the CSI driver clones the source volume.
+
+How It Works (vsphere):
   1. StorageMap entry includes an OffloadPlugin with vendor + secret
   2. Controller creates a VSphereXcopyVolumePopulator per disk
   3. Populator pod uses VAAI/XCOPY to clone directly on the array
   4. Plans with mixed VDDK/offload pairs are rejected at validation
+
+How It Works (csiVolumeImport):
+  1. StorageMap entry includes an OffloadPlugin with vendor + secret
+  2. Controller creates a PVC with CSI import annotations per disk
+  3. CSI driver clones the source array volume directly
 
 Supported Vendors
 -----------------
@@ -302,8 +316,8 @@ Secret Keys (Environment Variables)
     ONTAP_SVM                      SVM name (ontap)
     STORAGE_HTTP_TIMEOUT_SECONDS   HTTP timeout in seconds (optional)
 
-Clone Methods
--------------
+Clone Methods (vsphere only)
+----------------------------
   vib (default)   Custom VIB on ESXi hosts, no SSH needed
   ssh             SSH to ESXi hosts with restricted commands
 
@@ -369,12 +383,24 @@ Examples
       --default-offload-migration-hosts "host-10+host-11" \
       --default-offload-secret my-storage-secret
 
+  CSI Volume Import (HPE Primera/3PAR):
+    kubectl mtv create mapping storage --name csi-offload \
+      --source vsphere-prod --target host \
+      --storage-pairs "hpe-ds:hpe-sc;offloadPlugin=csiVolumeImport;offloadVendor=primera3par" \
+      --default-offload-secret hpe-creds
+
 Important Constraints
 ---------------------
+  General:
   - A plan cannot mix VDDK and offload storage pairs (all or none)
   - Source VMDK and target PVC must be on the SAME physical storage array
+  - Works with vVol, RDM, and VMFS-backed disks
+
+  vsphere (XCOPY) only:
   - ESXi hosts must have VAAI enabled
-  - Works with vVol, RDM, and VMFS-backed disks`,
+
+  csiVolumeImport only:
+  - Currently supports primera3par vendor only`,
 	},
 }
 

--- a/pkg/util/flags/output_format_type.go
+++ b/pkg/util/flags/output_format_type.go
@@ -42,6 +42,22 @@ func ValidateOffloadVendor(vendor string) error {
 	return fmt.Errorf("must be one of: %s", strings.Join(OffloadVendors, "|"))
 }
 
+// OffloadPlugins is the list of supported offload plugin types.
+var OffloadPlugins = []string{"vsphere", "csiVolumeImport"}
+
+// OffloadPluginHelp is the help text for --default-offload-plugin flags.
+var OffloadPluginHelp = "Default offload plugin type for storage pairs (" + strings.Join(OffloadPlugins, "|") + ")"
+
+// ValidateOffloadPlugin returns nil if the plugin is in the supported list, or an error otherwise.
+func ValidateOffloadPlugin(plugin string) error {
+	for _, p := range OffloadPlugins {
+		if plugin == p {
+			return nil
+		}
+	}
+	return fmt.Errorf("must be one of: %s", strings.Join(OffloadPlugins, "|"))
+}
+
 // OutputFormatTypeFlag implements pflag.Value interface for output format type validation
 type OutputFormatTypeFlag struct {
 	value        string


### PR DESCRIPTION
## Summary
- Add `csiVolumeImport` as a new `--default-offload-plugin` option alongside `vsphere`
- Uses the CSI driver's native import capability to migrate VVol/RDM disks — no populator pod, no CR, no service account launched
- Reuses existing `--default-offload-secret` and `--default-offload-vendor` flags (no new flags needed)

## Changes
- Add `OffloadPlugins` list and `ValidateOffloadPlugin()` to flags package
- Add `case "csiVolumeImport"` in storage pair parsing (mapping create, plan create, patch)
- Update flag help text, shell completions, and help topics
- Add test coverage for the new plugin type

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/cmd/create/mapping/... ./pkg/cmd/create/plan/storage/mapper/... ./pkg/util/flags/...` passes
- [x] `go vet ./...` passes
- [x] Manually tested `oc mtv create plan` with `--default-offload-plugin csiVolumeImport` against a live cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the `csiVolumeImport` storage offload plugin, including offload secret/vendor configuration.
  - Expanded `--default-offload-plugin` and related flag behavior and shell completion to cover all supported offload plugins.
- **Documentation**
  - Updated the offload help topic to document separate vSphere vs CSI import flows and added a CSI volume import example.
- **Bug Fixes**
  - Standardized offload plugin validation and improved error messaging; updated tests to cover multiple valid plugins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->