### PR TITLE
Add --hyperv-management-type flag for HyperV providers

### DIFF
--- a/cmd/create/provider.go
+++ b/cmd/create/provider.go
@@ -40,6 +40,7 @@ func NewProviderCmd(kubeConfigFlags *genericclioptions.ConfigFlags) *cobra.Comma
 
 	// HyperV specific flags
 	var smbUrl, smbUser, smbPassword string
+	var hypervMgmtType string
 
 	// Azure specific flags
 	var azureTenantID, azureSubscriptionID, azureClientID, azureClientSecret string
@@ -180,6 +181,7 @@ Credentials can be provided directly via flags or through an existing Kubernetes
 				SMBUrl:                     smbUrl,
 				SMBUser:                    smbUser,
 				SMBPassword:                smbPassword,
+				HyperVMgmtType:             hypervMgmtType,
 				AzureTenantID:              azureTenantID,
 				AzureSubscriptionID:        azureSubscriptionID,
 				AzureClientID:              azureClientID,
@@ -236,6 +238,8 @@ Credentials can be provided directly via flags or through an existing Kubernetes
 	cmd.Flags().StringVar(&smbUrl, "smb-url", "", "SMB share URL for HyperV (e.g., //server/share)")
 	cmd.Flags().StringVar(&smbUser, "smb-user", "", "SMB username (defaults to HyperV username)")
 	cmd.Flags().StringVar(&smbPassword, "smb-password", "", "SMB password (defaults to HyperV password)")
+	cmd.Flags().StringVar(&hypervMgmtType, "hyperv-management-type", "", "HyperV management type (e.g., cluster)")
+
 
 	// Azure specific flags
 	cmd.Flags().StringVar(&azureTenantID, "azure-tenant-id", "", "Azure AD tenant ID")

--- a/cmd/patch/provider.go
+++ b/cmd/patch/provider.go
@@ -94,6 +94,7 @@ func NewProviderCmd(kubeConfigFlags *genericclioptions.ConfigFlags) *cobra.Comma
 	cmd.Flags().StringVar(&opts.SMBUrl, "smb-url", "", "SMB share URL for HyperV (e.g., //server/share)")
 	cmd.Flags().StringVar(&opts.SMBUser, "smb-user", "", "SMB username (defaults to HyperV username)")
 	cmd.Flags().StringVar(&opts.SMBPassword, "smb-password", "", "SMB password (defaults to HyperV password)")
+	cmd.Flags().StringVar(&opts.HyperVMgmtType, "hyperv-management-type", "", "HyperV management type (e.g., cluster)")
 
 	// EC2 specific flags
 	cmd.Flags().StringVar(&opts.EC2Region, "ec2-region", "", "AWS region where source EC2 instances are located")

--- a/pkg/cmd/create/provider/hyperv/hyperv.go
+++ b/pkg/cmd/create/provider/hyperv/hyperv.go
@@ -114,6 +114,13 @@ func CreateProvider(configFlags *genericclioptions.ConfigFlags, options provider
 	provider.Spec.Type = &providerTypeValue
 	provider.Spec.URL = options.URL
 
+	// Set settings if provided
+	if options.HyperVMgmtType != "" {
+		provider.Spec.Settings = map[string]string{
+			"managementType": options.HyperVMgmtType,
+		}
+	}
+
 	// Create or use the Secret
 	var createdSecret *corev1.Secret
 	var err error

--- a/pkg/cmd/create/provider/providerutil/options.go
+++ b/pkg/cmd/create/provider/providerutil/options.go
@@ -24,9 +24,10 @@ type ProviderOptions struct {
 	ProjectName string
 	RegionName  string
 	// HyperV specific options
-	SMBUrl      string
-	SMBUser     string
-	SMBPassword string
+	SMBUrl             string
+	SMBUser            string
+	SMBPassword        string
+	HyperVMgmtType     string
 	// EC2 specific options
 	EC2Region             string
 	EC2TargetRegion       string

--- a/pkg/cmd/patch/provider/patch.go
+++ b/pkg/cmd/patch/provider/patch.go
@@ -57,9 +57,10 @@ type PatchProviderOptions struct {
 	AutoTargetCredentials bool
 
 	// HyperV settings
-	SMBUrl      string
-	SMBUser     string
-	SMBPassword string
+	SMBUrl         string
+	SMBUser        string
+	SMBPassword    string
+	HyperVMgmtType string
 
 	// Azure settings
 	AzureTenantID              string
@@ -223,6 +224,15 @@ func PatchProvider(opts PatchProviderOptions) error {
 		if opts.AzureSnapshotResourceGroup != "" {
 			klog.V(2).Infof("Updating Azure snapshotResourceGroup to '%s'", opts.AzureSnapshotResourceGroup)
 			currentSettings["snapshotResourceGroup"] = opts.AzureSnapshotResourceGroup
+			providerUpdated = true
+		}
+	}
+
+	// Update HyperV settings for HyperV providers
+	if providerType == "hyperv" {
+		if opts.HyperVMgmtType != "" {
+			klog.V(2).Infof("Updating HyperV managementType to '%s'", opts.HyperVMgmtType)
+			currentSettings["managementType"] = opts.HyperVMgmtType
 			providerUpdated = true
 		}
 	}


### PR DESCRIPTION
## Summary
- Add `--hyperv-management-type` flag to `create provider` and `patch provider` commands for HyperV providers
- When set, populates `spec.settings.managementType` on the Provider CR (e.g., `cluster` for Hyper-V failover cluster management)
- Consistent with how other providers (vSphere, EC2, Azure) handle `spec.settings`

## Test plan
- [ ] `oc mtv create provider --type hyperv --hyperv-management-type cluster ...` sets `spec.settings.managementType: cluster`
- [ ] `oc mtv patch provider --hyperv-management-type cluster ...` patches the setting on an existing HyperV provider
- [ ] Omitting the flag produces a provider with no `settings` (existing behavior preserved)
- [ ] `--dry-run` output includes the setting when provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying the Hyper-V management type when creating a provider.
  * Added the ability to update the Hyper-V management type when patching an existing provider.
  * The selected management type is saved with the provider configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->